### PR TITLE
Minor fix to Audit & Removal tasks

### DIFF
--- a/src/main/java/org/dspace/ctask/replicate/CompareWithAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/CompareWithAIP.java
@@ -82,6 +82,9 @@ public class CompareWithAIP extends AbstractCurationTask
                 File packDir = repMan.stage(storeGroupName, id);
                 File archive = packer.pack(packDir);
                 String chkSum = Utils.checksum(archive, "MD5");
+                // remove local archive file -- it's no longer needed
+                archive.delete();
+
                 // compare with replica
                 String repChkSum = repMan.objectAttribute(storeGroupName, objId, "checksum");
                 if (! chkSum.equals(repChkSum))

--- a/src/main/java/org/dspace/ctask/replicate/RemoveAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/RemoveAIP.java
@@ -154,7 +154,10 @@ public class RemoveAIP extends AbstractCurationTask {
                 repMan.removeObject(storeGroupName, memId);
                 report("Removing AIP for: " + memId);
             }
-            // remove deletion catalog
+            
+            // remove local deletion catalog
+            catFile.delete();
+            // remove remote deletion catalog
             repMan.removeObject(deleteGroupName, catId);
 
             result = "AIP for '" + id + "' has been removed (along with any child object AIPs)";


### PR DESCRIPTION
The Audit AIP and Removal AIP tasks were not properly cleaning up after themselves.  This fix ensures they remove all locally cached files after completion.
