### PR TITLE
Upgrade to DuraCloud API v2.1.3, which provides a backported connection bug fix related to the most recent release of DuraCloud.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,10 +22,10 @@
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
         <dspace.version>[1.8.0,1.9.0)</dspace.version>
-        <!-- WARNING: MUST BE version 2.1.2 as that is the last version of the
+        <!-- WARNING: version CANNOT be > 2.1.x as that is the last version of the
              DuraCloud API which supported Java 6, and DSpace 1.8.x requires Java 6.
              See https://jira.duraspace.org/browse/DS-1081 which wasn't resolved until DSpace 3.0. -->
-        <duracloud.version>2.1.2</duracloud.version>
+        <duracloud.version>2.1.3</duracloud.version>
     </properties>
   
     <build>


### PR DESCRIPTION
With the release of DuraCloud 2.4.0, users of 'dspace-replicate' 1.x (with DSpace 1.8.x) have reported connection problems to DuraCloud.  

These DuraCloud connection errors would look like:

java.io.IOException: Unable to connect to the DuraCloud Primary Content Store. Please check the DuraCloud connection/authentication settings in your 'duracloud.cfg' file.
...
Caused by: org.duracloud.error.ContentStoreException: Error retrieving content stores. null

This connection issue was a small issue in the older 2.1.x version of the DuraCloud API (around retrieving content stores, as the error implies) and it has now been resolved in DuraCloud API v2.1.3.  Unfortunately, 'dspace-replicate' 1.x is limited to using the 2.1.x DuraCloud API, as it was the last version that supported Java 6.

I'll merge this fix shortly, as I've verified it resolves the connection issues with latest DuraCloud. I'll also release a new version of the Replication Task Suite which affected DSpace 1.8.x users can upgrade to.
