### PR TITLE
DS-1999 Ensure AIP exists in remote storage before creating a DELETION_RECORD.

### DIFF
--- a/src/main/java/org/dspace/ctask/replicate/METSReplicateConsumer.java
+++ b/src/main/java/org/dspace/ctask/replicate/METSReplicateConsumer.java
@@ -64,7 +64,7 @@ import static org.dspace.event.Event.*;
  * # consumer to manage content replication (Replication Task Suite add-on)
  * event.consumer.replicate.class = org.dspace.ctask.replicate.METSReplicateConsumer
  * event.consumer.replicate.filters = Community|Collection|Item|Group|EPerson+All
- * 
+ *
  * @author tdonohue
  * @author richardrodgers
  */
@@ -96,6 +96,8 @@ public class METSReplicateConsumer implements Consumer {
     private List<String> delTasks = null;
     // create deletion catalogs?
     private boolean catalogDeletes = false;
+    // Group where all AIPs are stored
+    private final String storeGroupName = ConfigurationManager.getProperty("replicate", "group.aip.name");
     // Group where object deletion catalog/records are stored
     private final String deleteGroupName = ConfigurationManager.getProperty("replicate", "group.delete.name");
 
@@ -260,7 +262,7 @@ public class METSReplicateConsumer implements Consumer {
                         }
                     }
                     break;
-                
+
                 case REMOVE: //REMOVE = Remove an object from a container or group
                 case DELETE: //DELETE = Delete an object (actually destroy it)
                     // For REMOVE & DELETE, the Handle of object being deleted is found in Event Detail
@@ -318,7 +320,7 @@ public class METSReplicateConsumer implements Consumer {
             }
             taskPMap.clear();
         }
-       
+
         // if there any uncommitted deletions, record them now
         if (delObjId != null)
         {
@@ -450,25 +452,34 @@ public class METSReplicateConsumer implements Consumer {
         // write out deletion catalog if defined
         if (catalogDeletes)
         {
-            //Create a deletion catalog (in BagIt format) of all deleted objects
-            Packer packer = new CatalogPacker(delObjId, delOwnerId, delMemIds);
-            try
+            //First, check if this object has an AIP in storage
+            boolean found = repMan.objectExists(storeGroupName, delObjId);
+
+            // If the object has an AIP, then create a deletion catalog
+            // If there's no AIP, then there's no need for a deletion
+            // catalog as the object isn't backed up & cannot be restored!
+            if(found)
             {
-                // Create a new deletion catalog (with default file extension / format)
-                // and store it in the deletion group store
-                String catID = repMan.deletionCatalogId(delObjId, null);
-                File packDir = repMan.stage(deleteGroupName, catID);
-                File archive = packer.pack(packDir);
-                // Create a deletion catalog in deletion archive location.
-                repMan.transferObject(deleteGroupName, archive);
-            }
-            catch (AuthorizeException authE)
-            {
-                throw new IOException(authE);
-            }
-            catch (SQLException sqlE)
-            {
-                throw new IOException(sqlE);
+                //Create a deletion catalog (in BagIt format) of all deleted objects
+                Packer packer = new CatalogPacker(delObjId, delOwnerId, delMemIds);
+                try
+                {
+                    // Create a new deletion catalog (with default file extension / format)
+                    // and store it in the deletion group store
+                    String catID = repMan.deletionCatalogId(delObjId, null);
+                    File packDir = repMan.stage(deleteGroupName, catID);
+                    File archive = packer.pack(packDir);
+                    // Create a deletion catalog in deletion archive location.
+                    repMan.transferObject(deleteGroupName, archive);
+                }
+                catch (AuthorizeException authE)
+                {
+                    throw new IOException(authE);
+                }
+                catch (SQLException sqlE)
+                {
+                    throw new IOException(sqlE);
+                }
             }
         }
         // reset for next events
@@ -546,7 +557,7 @@ public class METSReplicateConsumer implements Consumer {
             }
         }
     }
-    
+
     /**
      * Parse the list of Consumer tasks to perform.  This list of tasks
      * is in the 'replicate.cfg' file.


### PR DESCRIPTION
Fixes DS-1999.  First checks to see if the AIP exists in remote storage (backup storage) before any DELETION_RECORD catalog file is written.  If the AIP does not exist, then the DELETION_RECORD is not created, as the object was never backed up.

https://jira.duraspace.org/browse/DS-1999
