### PR TITLE
increasing Duracloud API version to latest stable, 3.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+sudo: false
+script: mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <!-- DSpace Version Information (supported version of DSpace) -->
         <dspace.version>[3.0,4.0)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
-        <duracloud.version>2.3.1</duracloud.version>
+        <duracloud.version>3.5.0</duracloud.version>
     </properties>
   
     <build>


### PR DESCRIPTION
This was suggested by @tdonohue, this PR increases the version number of the DuraCloud API used by RTS to the current stable version, 3.5.0. I also added a very basic .travis.yml configuration, which simply runs ```mvn clean verify``` to ensure the code compiles correctly.