### PR TITLE
Fix JavaDocs errors

### DIFF
--- a/src/main/java/org/dspace/ctask/replicate/AbstractPackagerTask.java
+++ b/src/main/java/org/dspace/ctask/replicate/AbstractPackagerTask.java
@@ -58,7 +58,7 @@ public abstract class AbstractPackagerTask extends AbstractCurationTask
      * myreplacetask.createMetadataFields = true
      * myreplacetask.[any-supported-option] = [any-supported-value]
      * 
-     * @param moduleName Module name to load configuration file & settings from
+     * @param moduleName Module name to load configuration file and settings from
      * @return configured PackageParameters (or null, if configurations not found)
      * @see org.dspace.content.packager.PackageParameters
      */

--- a/src/main/java/org/dspace/ctask/replicate/BagItReplaceWithAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/BagItReplaceWithAIP.java
@@ -47,7 +47,7 @@ public class BagItReplaceWithAIP extends AbstractCurationTask {
      * whatever information is contained in the AIP.
      * @param dso the DSpace object to replace
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException 

--- a/src/main/java/org/dspace/ctask/replicate/BagItReplicateConsumer.java
+++ b/src/main/java/org/dspace/ctask/replicate/BagItReplicateConsumer.java
@@ -117,9 +117,9 @@ public class BagItReplicateConsumer implements Consumer {
      * replication service, and can be used either to recover from mistaken
      * deletions, or purge the replica store when desired.
      *
-     * @param ctx
-     * @param event
-     * @throws Exception
+     * @param ctx Context
+     * @param event Event
+     * @throws Exception if error
      */
     @Override
     public void consume(Context ctx, Event event) throws Exception

--- a/src/main/java/org/dspace/ctask/replicate/BagItRestoreFromAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/BagItRestoreFromAIP.java
@@ -64,7 +64,7 @@ public class BagItRestoreFromAIP extends AbstractCurationTask {
      * always returns an exception. 
      * @param dso DSpace Object to recover
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if IO error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException {
@@ -78,7 +78,7 @@ public class BagItRestoreFromAIP extends AbstractCurationTask {
      * @param ctx current DSpace context
      * @param id identifier of object to restore
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if IO error
      */
     @Override
     public int perform(Context ctx, String id) throws IOException 
@@ -120,7 +120,7 @@ public class BagItRestoreFromAIP extends AbstractCurationTask {
      * @param ctx current DSpace Context
      * @param repMan ReplicaManager (used to access ObjectStore)
      * @param id Identifier of object in ObjectStore
-     * @throws IOException 
+     * @throws IOException if IO error
      */
     private void recover(Context ctx, ReplicaManager repMan, String id) throws IOException 
     {
@@ -152,7 +152,7 @@ public class BagItRestoreFromAIP extends AbstractCurationTask {
      * @param archive AIP package file 
      * @param objId identifier of object we are restoring
      * @param props properties which control how item is restored
-     * @throws IOException 
+     * @throws IOException if IO error
      */
     private void recoverItem(Context ctx, File archive, String objId, Properties props) throws IOException 
     {
@@ -191,7 +191,7 @@ public class BagItRestoreFromAIP extends AbstractCurationTask {
      * @param archive AIP package file 
      * @param collId identifier of collection we are restoring
      * @param commId identifier of parent community for this collection
-     * @throws IOException 
+     * @throws IOException if IO error
      */
     private void recoverCollection(Context ctx, File archive, String collId, String commId) throws IOException 
     {
@@ -219,7 +219,7 @@ public class BagItRestoreFromAIP extends AbstractCurationTask {
      * @param archive AIP package file 
      * @param commId identifier of community we are restoring
      * @param parentId identifier of parent community (if any) for community
-     * @throws IOException 
+     * @throws IOException if IO error
      */
     private void recoverCommunity(Context ctx, File archive, String commId, String parentId) throws IOException 
     {

--- a/src/main/java/org/dspace/ctask/replicate/CompareWithAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/CompareWithAIP.java
@@ -11,7 +11,6 @@ package org.dspace.ctask.replicate;
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
-import org.apache.log4j.Logger;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
@@ -62,7 +61,7 @@ public class CompareWithAIP extends AbstractCurationTask
      * Perform 'Compare with AIP' task
      * @param dso DSpace Object to perform on
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException
@@ -125,7 +124,7 @@ public class CompareWithAIP extends AbstractCurationTask
      * container itself).
      * @param repMan ReplicaManager (used to access ObjectStore)
      * @param dso DSpace Object
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     private void auditExtent(ReplicaManager repMan, DSpaceObject dso) throws IOException
     {
@@ -197,7 +196,7 @@ public class CompareWithAIP extends AbstractCurationTask
      * @param repMan ReplicaManager  (used to access ObjectStore)
      * @param dso DSpaceObject
      * @return true if replica exists, false otherwise
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     private boolean checkReplica(ReplicaManager repMan, DSpaceObject dso) throws IOException
     {

--- a/src/main/java/org/dspace/ctask/replicate/FetchAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/FetchAIP.java
@@ -38,7 +38,7 @@ public class FetchAIP extends AbstractCurationTask
      * Perform the 'Fetch AIP' task
      * @param dso DSpace Object to perform on
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException
@@ -65,7 +65,7 @@ public class FetchAIP extends AbstractCurationTask
      * @param ctx DSpace Context (this param is ignored for this task)
      * @param id ID of object whose AIP should be fetched
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(Context ctx, String id) throws IOException

--- a/src/main/java/org/dspace/ctask/replicate/FilteredFileTaskQueue.java
+++ b/src/main/java/org/dspace/ctask/replicate/FilteredFileTaskQueue.java
@@ -56,7 +56,7 @@ public class FilteredFileTaskQueue extends FileTaskQueue
      *        a token which must be presented to release the queue
      * @return set
      *        the current set of queued unique task entries
-     * @throws IOException
+     * @throws IOException if I/O error
      */
     @Override
     public synchronized Set<TaskQueueEntry> dequeue(String queueName, long ticket)

--- a/src/main/java/org/dspace/ctask/replicate/METSReplicateConsumer.java
+++ b/src/main/java/org/dspace/ctask/replicate/METSReplicateConsumer.java
@@ -135,9 +135,9 @@ public class METSReplicateConsumer implements Consumer {
      * replication service, and can be used either to recover from mistaken
      * deletions, or purge the replica store when desired.
      *
-     * @param ctx
-     * @param event
-     * @throws Exception
+     * @param ctx Context
+     * @param event Event
+     * @throws Exception if error
      */
     @Override
     public void consume(Context ctx, Event event) throws Exception
@@ -384,7 +384,7 @@ public class METSReplicateConsumer implements Consumer {
      * @param ctx current DSpace Context
      * @param id Object on which the delete/remove event was triggered
      * @param event event that was triggered
-     * @throws Exception
+     * @throws Exception if error
      */
     private void deleteEvent(Context ctx, String id, Event event) throws Exception
     {

--- a/src/main/java/org/dspace/ctask/replicate/METSRestoreFromAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/METSRestoreFromAIP.java
@@ -57,7 +57,7 @@ public class METSRestoreFromAIP extends AbstractPackagerTask
      * @param ctx current DSpace Context
      * @param id the ID of DSpace object to restore/replace
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(Context ctx, String id) throws IOException
@@ -135,7 +135,7 @@ public class METSRestoreFromAIP extends AbstractPackagerTask
      * @param repMan ReplicaManager
      * @param archive File in replica archive
      * @param pkgParams PackageParameters (may specify restore/replace mode, recursion, etc.)
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     private void restoreObject(ReplicaManager repMan, File archive, PackageParameters pkgParams)
              throws IOException

--- a/src/main/java/org/dspace/ctask/replicate/MoveToTrashSingleAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/MoveToTrashSingleAIP.java
@@ -51,7 +51,7 @@ public class MoveToTrashSingleAIP extends AbstractCurationTask
      * Actually generates the AIP and transmits it to the replica ObjectStore
      * @param dso DSpace Object to perform on
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException
@@ -79,7 +79,7 @@ public class MoveToTrashSingleAIP extends AbstractCurationTask
      * @param ctx DSpace Context (this param is ignored for this task)
      * @param id ID of object whose AIP should be moved
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(Context ctx, String id) throws IOException

--- a/src/main/java/org/dspace/ctask/replicate/ObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/ObjectStore.java
@@ -21,36 +21,39 @@ public interface ObjectStore {
 
     /**
      * Initializes the storage service for use.
+     * @throws IOException if I/O error
      */
     void init() throws IOException;
 
     /**
      * Returns whether an object with the passed id exists in the store.
      * 
-     * @param group
-     * @param id
+     * @param group Group
+     * @param id ID
      * @return true if a representation of the object named by ID exists
+     * @throws IOException if I/O error
      */
     boolean objectExists(String group, String id) throws IOException;
 
     /**
      * Obtains attributes of the representation of the object with passed ID.
      * 
-     * @param group
-     * @param id
+     * @param group Group
+     * @param id ID
      * @param attrName - name of the attribute
      * @return value of the attribute if it exists, else null
-     * @throws IOException
+     * @throws IOException if I/O error
      */
     String objectAttribute(String group, String id, String attrName) throws IOException;
 
     /**
      * Fetches a copy of the object with passed ID, and places it in passed file.
      * 
-     * @param group
-     * @param id
+     * @param group Group
+     * @param id ID
+     * @param file File
      * @return number of bytes the replica used
-     * @throws IOException
+     * @throws IOException if I/O error
      */
     long fetchObject(String group, String id, File file) throws IOException;
     
@@ -58,30 +61,32 @@ public interface ObjectStore {
     /**
      * Transfers a copy of this file to the object store
      * 
-     * @param group
+     * @param group Group
      * @param file the file to transfer to store
      * @return number of bytes transferred to store or 0 if transfer failed.
-     * @throws IOException
+     * @throws IOException if I/O error
      */
     long transferObject(String group, File file) throws IOException;
 
     /**
      * Removes the passed object from the store.
      * 
-     * @param group
+     * @param group Group
      * @param id the id of the object to remove
      * @return number of bytes the object was using, or 0 if
      *         object did not exist.
+     * @throws IOException if I/O error
      */
     long removeObject(String group, String id) throws IOException;
     
     /**
      * Moves the passed object from one storage group to another.
      * 
-     * @param srcGroup source group
+     * @param srcgroup source group
      * @param destGroup destination group
      * @param id the id of the object to move between groups
      * @return number of bytes moved or 0 if move failed.
+     * @throws IOException if I/O error
      */
     long moveObject(String srcgroup, String destGroup, String id) throws IOException;
 }

--- a/src/main/java/org/dspace/ctask/replicate/ReadOdometer.java
+++ b/src/main/java/org/dspace/ctask/replicate/ReadOdometer.java
@@ -32,7 +32,7 @@ public class ReadOdometer extends AbstractCurationTask
      * Performs the "Read Odometer" task.
      * @param dso this param is ignored, as the odometer is sitewide
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException

--- a/src/main/java/org/dspace/ctask/replicate/RemoveAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/RemoveAIP.java
@@ -46,7 +46,7 @@ public class RemoveAIP extends AbstractCurationTask {
      * 
      * @param dso the DSpace object
      * @return integer which represents Curator return status
-     * @throws IOException
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException 
@@ -62,7 +62,7 @@ public class RemoveAIP extends AbstractCurationTask {
      * replica ObjectStore.
      * @param repMan ReplicaManager (used to access ObjectStore)
      * @param dso the DSpace object whose replicas we will remove
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     private void remove(ReplicaManager repMan, DSpaceObject dso) throws IOException 
     {
@@ -120,7 +120,7 @@ public class RemoveAIP extends AbstractCurationTask {
      * @param ctx current DSpace Context
      * @param id Identifier of the object to be removed.
      * @return integer which represents Curator return status
-     * @throws IOException
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(Context ctx, String id) throws IOException 

--- a/src/main/java/org/dspace/ctask/replicate/TransmitAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/TransmitAIP.java
@@ -29,7 +29,7 @@ import org.dspace.pack.PackerFactory;
  * in 'replicate.cfg'. See the org.dspace.pack.PackerFactory for more info.
  * <P>
  * This task is "suspendable" when invoked from the UI. If a single AIP fails
- * to be generated & transmitted to storage, we should inform the user ASAP.
+ * to be generated and transmitted to storage, we should inform the user ASAP.
  * We wouldn't want them to assume everything was transferred successfully, 
  * if there were actually underlying errors.
  * <P>
@@ -52,7 +52,7 @@ public class TransmitAIP extends AbstractCurationTask
      * Actually generates the AIP and transmits it to the replica ObjectStore
      * @param dso DSpace Object to perform on
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException

--- a/src/main/java/org/dspace/ctask/replicate/TransmitSingleAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/TransmitSingleAIP.java
@@ -27,8 +27,7 @@ import org.dspace.curate.Distributive;
  * 
  * @author richardrodgers
  * @see TransmitAIP
- * @see PackerFactory
- * @see ReplicateConsumer
+ * @see org.dspace.pack.PackerFactory
  */
 @Distributive
 public class TransmitSingleAIP extends TransmitAIP {}

--- a/src/main/java/org/dspace/ctask/replicate/VerifyAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/VerifyAIP.java
@@ -45,7 +45,7 @@ public class VerifyAIP extends AbstractCurationTask
      * Simply tests for presence of AIP in replica ObjectStore.
      * @param dso the DSpace Object to verify
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException
@@ -73,7 +73,7 @@ public class VerifyAIP extends AbstractCurationTask
      * @param ctx DSpace Context (this param is ignored for this task)
      * @param id ID of object to verify
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error 
      */
     @Override
     public int perform(Context ctx, String id) throws IOException

--- a/src/main/java/org/dspace/ctask/replicate/checkm/CompareWithManifest.java
+++ b/src/main/java/org/dspace/ctask/replicate/checkm/CompareWithManifest.java
@@ -50,7 +50,7 @@ public class CompareWithManifest extends AbstractCurationTask
      * Perform 'Compare with Manifest' task
      * @param dso DSpace Object to perform on
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException
@@ -88,8 +88,8 @@ public class CompareWithManifest extends AbstractCurationTask
      * @param repMan Replication Manager
      * @param filename filename of object's manifest file
      * @param context current DSpace context
-     * @throws IOException
-     * @throws SQLException
+     * @throws IOException if I/O error
+     * @throws SQLException if database error
      * @return integer which represents Curator return status
      */
     private int checkManifest(ReplicaManager repMan, String filename, Context context) throws IOException, SQLException

--- a/src/main/java/org/dspace/ctask/replicate/checkm/FetchManifest.java
+++ b/src/main/java/org/dspace/ctask/replicate/checkm/FetchManifest.java
@@ -40,7 +40,7 @@ public class FetchManifest extends AbstractCurationTask
      * Perform 'Fetch Manifest' task
      * @param dso DSpace Object to perform on
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException

--- a/src/main/java/org/dspace/ctask/replicate/checkm/RemoveManifest.java
+++ b/src/main/java/org/dspace/ctask/replicate/checkm/RemoveManifest.java
@@ -45,7 +45,7 @@ public class RemoveManifest extends AbstractCurationTask {
      * 
      * @param dso the DSpace object
      * @return integer which represents Curator return status
-     * @throws IOException
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException 
@@ -66,7 +66,7 @@ public class RemoveManifest extends AbstractCurationTask {
      * manifests from the Replica ObjectStore.
      * @param repMan ReplicaManager (used to access ObjectStore)
      * @param dso the DSpace Object
-     * @throws IOException 
+     * @throws IOException if I/O error 
      */
     private void remove(ReplicaManager repMan, DSpaceObject dso) throws IOException 
     {    
@@ -119,7 +119,7 @@ public class RemoveManifest extends AbstractCurationTask {
      * @param ctx current DSpace Context
      * @param id Identifier of the object to be removed.
      * @return integer which represents Curator return status
-     * @throws IOException
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(Context ctx, String id) throws IOException 
@@ -144,7 +144,7 @@ public class RemoveManifest extends AbstractCurationTask {
      * manifests from the Replica ObjectStore.
      * @param repMan ReplicaManager (used to access ObjectStore)
      * @param id the DSpace Object's identifier
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     private void deleteManifest(ReplicaManager repMan, String id) throws IOException 
     {

--- a/src/main/java/org/dspace/ctask/replicate/checkm/TransmitManifest.java
+++ b/src/main/java/org/dspace/ctask/replicate/checkm/TransmitManifest.java
@@ -62,7 +62,7 @@ public class TransmitManifest extends AbstractCurationTask {
      * Actually generates manifest and transmits to Replica ObjectStore
      * @param dso DSpace Object to perform on
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException
@@ -110,8 +110,8 @@ public class TransmitManifest extends AbstractCurationTask {
      * @param repMan ReplicaManager (used to access ObjectStore)
      * @param site the DSpace Site object
      * @return reference to manifest file generated for Community
-     * @throws IOException
-     * @throws SQLException 
+     * @throws IOException if I/O error
+     * @throws SQLException if database error
      */
     private File siteManifest(ReplicaManager repMan, Site site) throws IOException, SQLException
     {
@@ -151,8 +151,8 @@ public class TransmitManifest extends AbstractCurationTask {
      * @param repMan ReplicaManager (used to access ObjectStore)
      * @param comm the DSpace Community
      * @return reference to manifest file generated for Community
-     * @throws IOException
-     * @throws SQLException 
+     * @throws IOException if I/O error
+     * @throws SQLException if database error
      */
     private File communityManifest(ReplicaManager repMan, Community comm) throws IOException, SQLException
     {
@@ -198,8 +198,8 @@ public class TransmitManifest extends AbstractCurationTask {
      * @param repMan ReplicaManager (used to access ObjectStore)
      * @param coll the DSpace Collection
      * @return reference to manifest file generated for Collection
-     * @throws IOException
-     * @throws SQLException 
+     * @throws IOException if I/O error
+     * @throws SQLException if database error
      */
     private File collectionManifest(ReplicaManager repMan, Collection coll) throws IOException, SQLException
     {
@@ -237,8 +237,8 @@ public class TransmitManifest extends AbstractCurationTask {
      * @param repMan ReplicaManager (used to access ObjectStore)
      * @param item the DSpace Item
      * @return reference to manifest file generated for Item
-     * @throws IOException
-     * @throws SQLException 
+     * @throws IOException if I/O error
+     * @throws SQLException if database error
      */
     private File itemManifest(ReplicaManager repMan, Item item) throws IOException, SQLException
     {
@@ -319,7 +319,7 @@ public class TransmitManifest extends AbstractCurationTask {
      * Initialize a Writer for a Manifest file. Also, writes header to manifest file.
      * @param file file where manifest will be stored
      * @return reference to Writer
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     private Writer manifestWriter(File file) throws IOException
     {

--- a/src/main/java/org/dspace/ctask/replicate/checkm/VerifyManifest.java
+++ b/src/main/java/org/dspace/ctask/replicate/checkm/VerifyManifest.java
@@ -43,7 +43,7 @@ public class VerifyManifest extends AbstractCurationTask {
      * Perform the 'Verify Manifest' task
      * @param dso the DSpace Object to be verified
      * @return integer which represents Curator return status
-     * @throws IOException 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException

--- a/src/main/java/org/dspace/pack/Packer.java
+++ b/src/main/java/org/dspace/pack/Packer.java
@@ -25,9 +25,9 @@ public interface Packer
      *
      * @param packDir the locus of the packing
      * @return the packed archive file
-     * @throws AuthorizeException
-     * @throws IOException
-     * @throws SQLException
+     * @throws AuthorizeException if authorize error
+     * @throws IOException if I/O error
+     * @throws SQLException if database error
      */
     File pack(File packDir) throws AuthorizeException, IOException, SQLException;
 
@@ -35,9 +35,9 @@ public interface Packer
      * Unpacks (maps) the contents of the passed archive file into this object.
      *
      * @param archFile the archive file to unpack
-     * @throws AuthorizeException
-     * @throws IOException
-     * @throws SQLException
+     * @throws AuthorizeException if authorize error
+     * @throws IOException if I/O error
+     * @throws SQLException if database error
      */
     void unpack(File archFile) throws AuthorizeException, IOException, SQLException;
 
@@ -47,7 +47,7 @@ public interface Packer
      *
      * @param method how to estimate - not currently implemented
      * @return the bagged object size in bytes
-     * @throws SQLException
+     * @throws SQLException if database error
      */
     long size(String method) throws SQLException;
 
@@ -58,7 +58,7 @@ public interface Packer
      * That is, a list of Item bundle names taken to be exclusions, unless
      * preceeded by a '+", where the list is taken to be inclusive.
      *
-     * @param filter
+     * @param filter filter
      */
     void setContentFilter(String filter);
 

--- a/src/main/java/org/dspace/pack/bagit/Bag.java
+++ b/src/main/java/org/dspace/pack/bagit/Bag.java
@@ -46,9 +46,7 @@ import org.dspace.curate.Utils;
 
 // Warning - static import ahead!
 import static javax.xml.stream.XMLStreamConstants.*;
-import org.apache.log4j.Logger;
 import org.dspace.core.ConfigurationManager;
-import org.dspace.ctask.replicate.BagItRestoreFromAIP;
 
 /**
  * Bag represents a rudimentary bag conformant to LC Bagit spec - version 0.96.
@@ -56,7 +54,7 @@ import org.dspace.ctask.replicate.BagItRestoreFromAIP;
  * Although they don't have to be, these bags are 'wormy' - meaning that they
  * can be written only once (have no update semantics), and can be 'holey' -
  * meaning they can contain content by reference as well as inclusion. The
- * implementation provides 3 symmetrical interfaces for reading from & writing
+ * implementation provides 3 symmetrical interfaces for reading from and writing
  * to the bag: (1) A 'flat' reader and writer for line-oriented character
  * data, (2) an 'xml' reader and writer for XML documents, and (3) a 'raw'
  * stream-based reader and writer for uninterpreted binary data.
@@ -102,8 +100,8 @@ public class Bag {
      *     archive of a bag. Explode the archive and create a filled bag in
      *     the same directory as the archive file.
      * 
-     * @param baseFile
-     * @throws IOException
+     * @param baseFile File
+     * @throws IOException if I/O error
      */
     public Bag(File baseFile) throws IOException
     {

--- a/src/main/java/org/dspace/pack/mets/METSPacker.java
+++ b/src/main/java/org/dspace/pack/mets/METSPacker.java
@@ -35,7 +35,6 @@ import org.dspace.curate.Curator;
 import org.dspace.pack.Packer;
 
 import org.apache.log4j.Logger;
-import org.dspace.core.LogManager;
 
 /**
  * METSPacker packs and unpacks Item AIPs in METS compressed archives
@@ -99,9 +98,9 @@ public class METSPacker implements Packer
      * 
      * @param packDir the directory where this package should be created
      * @return the created package file
-     * @throws AuthorizeException
-     * @throws IOException
-     * @throws SQLException 
+     * @throws AuthorizeException if authorize error
+     * @throws IOException if I/O error
+     * @throws SQLException if database error
      */
     @Override
     public File pack(File packDir) throws AuthorizeException, IOException, SQLException
@@ -153,9 +152,9 @@ public class METSPacker implements Packer
      * using the configured AIP PackageIngester (in dspace.cfg)
      * 
      * @param archive the METS AIP package
-     * @throws AuthorizeException
-     * @throws IOException
-     * @throws SQLException 
+     * @throws AuthorizeException if authorize error
+     * @throws IOException if I/O error
+     * @throws SQLException if database error
      */
     @Override
     public void unpack(File archive) throws AuthorizeException, IOException, SQLException
@@ -177,9 +176,9 @@ public class METSPacker implements Packer
      * 
      * @param archive the METS AIP package
      * @param pkgParams the PackageParameters (if null, defaults to Recursive Replace settings)
-     * @throws AuthorizeException
-     * @throws IOException
-     * @throws SQLException 
+     * @throws AuthorizeException if authorize error
+     * @throws IOException if I/O error
+     * @throws SQLException if database error 
      */
     public void unpack(File archive, PackageParameters pkgParams) throws AuthorizeException, IOException, SQLException
     {
@@ -303,7 +302,7 @@ public class METSPacker implements Packer
      * Estimated size is currently just based on size of content files.
      * 
      * @return estimated storage size
-     * @throws SQLException 
+     * @throws SQLException if database error
      */
     private long siteSize() throws SQLException
     {
@@ -332,7 +331,7 @@ public class METSPacker implements Packer
      * 
      * @param community DSpace Community
      * @return estimated storage size
-     * @throws SQLException 
+     * @throws SQLException if database error
      */
     private long communitySize(Community community) throws SQLException
     {
@@ -362,7 +361,7 @@ public class METSPacker implements Packer
      * 
      * @param collection DSpace Collection
      * @return estimated storage size
-     * @throws SQLException 
+     * @throws SQLException  if database error
      */
     private long collectionSize(Collection collection) throws SQLException
     {
@@ -388,7 +387,7 @@ public class METSPacker implements Packer
      * 
      * @param item DSpace Item
      * @return estimated storage size
-     * @throws SQLException 
+     * @throws SQLException  if database error
      */
     private long itemSize(Item item) throws SQLException
     {


### PR DESCRIPTION
Fix all Javadocs errors reported by `mvn javadoc:javadoc`.  This should allow for releases using Java 8