### PR TITLE
Minor POM & Travis CI fixes for 3.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: java
 sudo: false
+jdk:
+  - oraclejdk8
+  - openjdk7
 script: mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
-        <version>7</version>
+        <version>9</version>
     </parent>
 
     <properties>
@@ -74,7 +74,7 @@
         <connection>scm:git:git@github.com:DSpace/dspace-replicate.git</connection>
         <developerConnection>scm:git:git@github.com:DSpace/dspace-replicate.git</developerConnection>
         <url>git@github.com:DSpace/dspace-replicate.git</url>
-        <tag>dspace-replicate-3.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencies>


### PR DESCRIPTION
This PR does some minor version updates to the 3.x POM, and ensures Travis CI tests build with both Java 7 and 8.  RTS v3.x supports DSpace v3-5, and several of those releases use Java 7.