### PR TITLE
allows bag functionality to work with dspace 5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>[3.0,4.0)</dspace.version>
+        <dspace.version>[5.0)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>2.2.0</duracloud.version>
     </properties>

--- a/src/main/java/org/dspace/pack/bagit/ItemPacker.java
+++ b/src/main/java/org/dspace/pack/bagit/ItemPacker.java
@@ -20,7 +20,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 
 import org.dspace.pack.Packer;
@@ -93,8 +93,8 @@ public class ItemPacker implements Packer
         // first user metadata
         writer.startStanza("metadata");
         Bag.Value value = new Bag.Value();
-        DCValue[] vals = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-        for (DCValue val : vals)
+        Metadatum[] vals = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        for (Metadatum val : vals)
         {
             value.addAttr("schema", val.schema);
             value.addAttr("element", val.element);


### PR DESCRIPTION
@tdonohue This change will allow bag functionality to work for users of dsapce 5x.  I've only tried it out with dsapce 5.1, but I think the change will work with the other versions.  