### PR TITLE
[DS-4285] Updates to dspace-replication 6.0 

### DIFF
--- a/src/main/java/org/dspace/ctask/replicate/AbstractPackagerTask.java
+++ b/src/main/java/org/dspace/ctask/replicate/AbstractPackagerTask.java
@@ -74,11 +74,13 @@ public abstract class AbstractPackagerTask extends AbstractCurationTask
             //loop through all properties in the config file
             for(String property : moduleProps)
             {
+                String propertyName = property.replace(moduleName + ".", "");
+
                 //Only obey the setting(s) beginning with this task's ID/name,
-                if(property.startsWith(this.taskId))
+                if(propertyName.startsWith(this.taskId))
                 {
                     //Parse out the option name by removing the "[taskID]." from beginning of property
-                    String option = property.replace(taskId + ".", "");
+                    String option = propertyName.replace(taskId + ".", "");
                     String value = configurationService.getProperty(property);
 
                     //Check which option is being set

--- a/src/main/java/org/dspace/ctask/replicate/checkm/TransmitManifest.java
+++ b/src/main/java/org/dspace/ctask/replicate/checkm/TransmitManifest.java
@@ -294,7 +294,7 @@ public class TransmitManifest extends AbstractCurationTask {
                                 break;
                             case 3:
                                 // length
-                                sb.append(bs.getSize());
+                                sb.append(bs.getSizeBytes());
                                 break;
                             case 4:
                                 // modified - use item level data?

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -74,22 +74,24 @@ public class DuraCloudObjectStore implements ObjectStore
         long size = 0L;
         try
         {
+            java.util.Map<String, String> props =
+                dcStore.getContentProperties(getSpaceID(group), getContentPrefix(group) + id);
+            size = Long.valueOf(props.get(ContentStore.CONTENT_SIZE));
              // DEBUG REMOVE
-            long start = System.currentTimeMillis();
+            // long start = System.currentTimeMillis();
             Content content = dcStore.getContent(getSpaceID(group), getContentPrefix(group) + id);
-            // DEBUG REMOVE
-            long elapsed = System.currentTimeMillis() - start;
+            // DEBUG REMOVE// long elapsed = System.currentTimeMillis() - start;
             //System.out.println("DC fetch content: " + elapsed);
-            size = Long.valueOf(content.getProperties().get(ContentStore.CONTENT_SIZE));
+            // size = Long.valueOf(content.getProperties().get(ContentStore.CONTENT_SIZE));
             FileOutputStream out = new FileOutputStream(file);
             // DEBUG remove
-            start = System.currentTimeMillis();
+            // start = System.currentTimeMillis();
             InputStream in = content.getStream();
             Utils.copy(in, out);
             in.close();
             out.close();
              // DEBUG REMOVE
-            elapsed = System.currentTimeMillis() - start;
+            // elapsed = System.currentTimeMillis() - start;
             //System.out.println("DC fetch download: " + elapsed);
         }
         catch (NotFoundException nfE)

--- a/src/main/java/org/dspace/pack/bagit/CollectionPacker.java
+++ b/src/main/java/org/dspace/pack/bagit/CollectionPacker.java
@@ -103,7 +103,7 @@ public class CollectionPacker implements Packer
         Bitstream logo = collection.getLogo();
         if (logo != null)
         {
-            bag.addData("logo", logo.getSize(), bitstreamService.retrieve(Curator.curationContext(), logo));
+            bag.addData("logo", logo.getSizeBytes(), bitstreamService.retrieve(Curator.curationContext(), logo));
         }
         bag.close();
         File archive = bag.deflate(archFmt);
@@ -147,7 +147,7 @@ public class CollectionPacker implements Packer
         Bitstream logo = collection.getLogo();
         if (logo != null)
         {
-            size += logo.getSize();
+            size += logo.getSizeBytes();
         }
         // proceed to items, unless 'norecurse' set
         if (! "norecurse".equals(method))

--- a/src/main/java/org/dspace/pack/bagit/CommunityPacker.java
+++ b/src/main/java/org/dspace/pack/bagit/CommunityPacker.java
@@ -97,7 +97,7 @@ public class CommunityPacker implements Packer
         Bitstream logo = community.getLogo();
         if (logo != null)
         {
-            bag.addData("logo", logo.getSize(), bitstreamService.retrieve(Curator.curationContext(), logo));
+            bag.addData("logo", logo.getSizeBytes(), bitstreamService.retrieve(Curator.curationContext(), logo));
         }
         bag.close();
         File archive = bag.deflate(archFmt);
@@ -140,7 +140,7 @@ public class CommunityPacker implements Packer
         Bitstream logo = community.getLogo();
         if (logo != null)
         {
-            size += logo.getSize();
+            size += logo.getSizeBytes();
         }
         // proceed to children, unless 'norecurse' set
         if (! "norecurse".equals(method))

--- a/src/main/java/org/dspace/pack/bagit/ItemPacker.java
+++ b/src/main/java/org/dspace/pack/bagit/ItemPacker.java
@@ -142,12 +142,12 @@ public class ItemPacker implements Packer
                     if (url != null)
                     {
                         // add reference to bag
-                        bag.addDataRef(relPath + seqId, bs.getSize(), url);
+                        bag.addDataRef(relPath + seqId, bs.getSizeBytes(), url);
                     }
                     else
                     {
                         // add bytes to bag
-                        bag.addData(relPath + seqId, bs.getSize(), bitstreamService.retrieve(Curator.curationContext(), bs));
+                        bag.addData(relPath + seqId, bs.getSizeBytes(), bitstreamService.retrieve(Curator.curationContext(), bs));
                     }
                 }
             }
@@ -260,7 +260,7 @@ public class ItemPacker implements Packer
             {
                 for (Bitstream bs : bundle.getBitstreams())
                 {
-                    size += bs.getSize();
+                    size += bs.getSizeBytes();
                 }
             }
         }
@@ -304,7 +304,7 @@ public class ItemPacker implements Packer
         for (RefFilter filter : refFilters)
         {
             if (filter.bundle.equals(bundle.getName()) &&
-                filter.size == bs.getSize())
+                filter.size == bs.getSizeBytes())
             {
                 return filter.url;
             }

--- a/src/main/java/org/dspace/pack/mets/METSPacker.java
+++ b/src/main/java/org/dspace/pack/mets/METSPacker.java
@@ -353,7 +353,7 @@ public class METSPacker implements Packer
         Bitstream logo = community.getLogo();
         if (logo != null)
         {
-            size += logo.getSize();
+            size += logo.getSizeBytes();
         }
         for (Community comm : community.getSubcommunities())
         {
@@ -383,7 +383,7 @@ public class METSPacker implements Packer
         Bitstream logo = collection.getLogo();
         if (logo != null)
         {
-            size += logo.getSize();
+            size += logo.getSizeBytes();
         }
         Iterator<Item> itemIter = itemService.findByCollection(Curator.curationContext(), collection);
         while (itemIter.hasNext())
@@ -412,7 +412,7 @@ public class METSPacker implements Packer
             {
                 for (Bitstream bs : bundle.getBitstreams())
                 {
-                    size += bs.getSize();
+                    size += bs.getSizeBytes();
                 }
             }
         }


### PR DESCRIPTION
There seem to be changes in DSpace 6.3 that cause problems for the replication suite.

Updates in the PR: 

- Change Bitstream getSize() to getSizeBytes() .
- Minor update to AbstractPackagerTask for string matching on mets-replicate properties.
- Use the DuraCloud API getContentProperties (HEAD) rather than {{get}} to obtain the transmitted file size.