### PR TITLE
[DS-4285] Replication Suite updates for DSpace 6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <!-- DSpace Version Information (supported version of DSpace) -->
         <dspace.version>[6.0,6.3)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
-        <duracloud.version>4.2.5</duracloud.version>
+        <duracloud.version>6.0.0</duracloud.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <packaging>jar</packaging>
     <name>DSpace Replication Task Suite</name>
     <url>https://wiki.duraspace.org/display/DSPACE/ReplicationTaskSuite</url>
-    <version>6.1-SNAPSHOT</version>
+    <version>6.0.1</version>
 
     <organization>
         <name>DuraSpace</name>
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>[6.0,7.0)</dspace.version>
+        <dspace.version>6.3</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>4.2.5</duracloud.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <packaging>jar</packaging>
     <name>DSpace Replication Task Suite</name>
     <url>https://wiki.duraspace.org/display/DSPACE/ReplicationTaskSuite</url>
-    <version>6.0.1</version>
+    <version>6.0</version>
 
     <organization>
         <name>DuraSpace</name>
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>6.3</dspace.version>
+        <dspace.version>[6.0,6.3)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>4.2.5</duracloud.version>
     </properties>

--- a/src/main/java/org/dspace/ctask/replicate/AbstractPackagerTask.java
+++ b/src/main/java/org/dspace/ctask/replicate/AbstractPackagerTask.java
@@ -74,11 +74,13 @@ public abstract class AbstractPackagerTask extends AbstractCurationTask
             //loop through all properties in the config file
             for(String property : moduleProps)
             {
+                String propertyName = property.replace(moduleName + ".", "");
+
                 //Only obey the setting(s) beginning with this task's ID/name,
-                if(property.startsWith(this.taskId))
+                if(propertyName.startsWith(this.taskId))
                 {
                     //Parse out the option name by removing the "[taskID]." from beginning of property
-                    String option = property.replace(taskId + ".", "");
+                    String option = propertyName.replace(taskId + ".", "");
                     String value = configurationService.getProperty(property);
 
                     //Check which option is being set

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -78,7 +78,7 @@ public class DuraCloudObjectStore implements ObjectStore
                 dcStore.getContentProperties(getSpaceID(group), getContentPrefix(group) + id);
             size = Long.valueOf(props.get(ContentStore.CONTENT_SIZE));
 
-             // DEBUG REMOVE
+            // DEBUG REMOVE
             // long start = System.currentTimeMillis();
             Content content = dcStore.getContent(getSpaceID(group), getContentPrefix(group) + id);
             // DEBUG REMOVE
@@ -91,7 +91,7 @@ public class DuraCloudObjectStore implements ObjectStore
             Utils.copy(in, out);
             in.close();
             out.close();
-             // DEBUG REMOVE
+            // DEBUG REMOVE
             // elapsed = System.currentTimeMillis() - start;
             //System.out.println("DC fetch download: " + elapsed);
         }

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -74,22 +74,25 @@ public class DuraCloudObjectStore implements ObjectStore
         long size = 0L;
         try
         {
+            java.util.Map<String, String> props =
+                dcStore.getContentProperties(getSpaceID(group), getContentPrefix(group) + id);
+            size = Long.valueOf(props.get(ContentStore.CONTENT_SIZE));
+
              // DEBUG REMOVE
-            long start = System.currentTimeMillis();
+            // long start = System.currentTimeMillis();
             Content content = dcStore.getContent(getSpaceID(group), getContentPrefix(group) + id);
             // DEBUG REMOVE
-            long elapsed = System.currentTimeMillis() - start;
+            // long elapsed = System.currentTimeMillis() - start;
             //System.out.println("DC fetch content: " + elapsed);
-            size = Long.valueOf(content.getProperties().get(ContentStore.CONTENT_SIZE));
             FileOutputStream out = new FileOutputStream(file);
             // DEBUG remove
-            start = System.currentTimeMillis();
+            // start = System.currentTimeMillis();
             InputStream in = content.getStream();
             Utils.copy(in, out);
             in.close();
             out.close();
              // DEBUG REMOVE
-            elapsed = System.currentTimeMillis() - start;
+            // elapsed = System.currentTimeMillis() - start;
             //System.out.println("DC fetch download: " + elapsed);
         }
         catch (NotFoundException nfE)


### PR DESCRIPTION
The RTS 6.0 dependency distributed via maven does not work when installed on DSpace 6.3 (or other 6.x versions). 

There appears to be a problem reading properties accessed via the dspace-api `ConfigurationService` (properties are defined in replicate-mets.cfg). This prevents recursive processing.

Also, the CONTENT_SIZE property is not returned by duracloud libraries when fetching objects from the store.  This results in a null pointer exception.





