### PR TITLE
[DS-4285] Updated for DSpace 6.4 and 7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <packaging>jar</packaging>
     <name>DSpace Replication Task Suite</name>
     <url>https://wiki.duraspace.org/display/DSPACE/ReplicationTaskSuite</url>
-    <version>6.0</version>
+    <version>6.1</version>
 
     <organization>
         <name>DuraSpace</name>
@@ -21,9 +21,9 @@
 
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>[6.0,6.3)</dspace.version>
+        <dspace.version>[6.4,7.0)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
-        <duracloud.version>4.2.5</duracloud.version>
+        <duracloud.version>6.0.1</duracloud.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>[6.4,7.0,7.0-SNAPSHOT)</dspace.version>
+        <dspace.version>[6.4,7.0-SNAPSHOT)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>6.0.1</duracloud.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <packaging>jar</packaging>
     <name>DSpace Replication Task Suite</name>
     <url>https://wiki.duraspace.org/display/DSPACE/ReplicationTaskSuite</url>
-    <version>6.1-SNAPSHOT</version>
+    <version>6.0.1</version>
 
     <organization>
         <name>DuraSpace</name>
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>[6.0,7.0)</dspace.version>
+        <dspace.version>6.3</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>4.2.5</duracloud.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <packaging>jar</packaging>
     <name>DSpace Replication Task Suite</name>
     <url>https://wiki.duraspace.org/display/DSPACE/ReplicationTaskSuite</url>
-    <version>6.0.1</version>
+    <version>6.0</version>
 
     <organization>
         <name>DuraSpace</name>
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>6.3</dspace.version>
+        <dspace.version>[6.0,6.3)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>4.2.5</duracloud.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>[6.4,7.0)</dspace.version>
+        <dspace.version>[6.4,7.0,7.0-SNAPSHOT)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>6.0.1</duracloud.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>[6.4,7.0-SNAPSHOT)</dspace.version>
+        <dspace.version>[6.4,7.0)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>6.0.1</duracloud.version>
     </properties>

--- a/src/main/java/org/dspace/ctask/replicate/AbstractPackagerTask.java
+++ b/src/main/java/org/dspace/ctask/replicate/AbstractPackagerTask.java
@@ -74,11 +74,13 @@ public abstract class AbstractPackagerTask extends AbstractCurationTask
             //loop through all properties in the config file
             for(String property : moduleProps)
             {
+                String propertyName = property.replace(moduleName + ".", "");
+
                 //Only obey the setting(s) beginning with this task's ID/name,
-                if(property.startsWith(this.taskId))
+                if(propertyName.startsWith(this.taskId))
                 {
                     //Parse out the option name by removing the "[taskID]." from beginning of property
-                    String option = property.replace(taskId + ".", "");
+                    String option = propertyName.replace(taskId + ".", "");
                     String value = configurationService.getProperty(property);
 
                     //Check which option is being set

--- a/src/main/java/org/dspace/ctask/replicate/checkm/TransmitManifest.java
+++ b/src/main/java/org/dspace/ctask/replicate/checkm/TransmitManifest.java
@@ -294,7 +294,7 @@ public class TransmitManifest extends AbstractCurationTask {
                                 break;
                             case 3:
                                 // length
-                                sb.append(bs.getSize());
+                                sb.append(bs.getSizeBytes());
                                 break;
                             case 4:
                                 // modified - use item level data?

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -78,7 +78,7 @@ public class DuraCloudObjectStore implements ObjectStore
                 dcStore.getContentProperties(getSpaceID(group), getContentPrefix(group) + id);
             size = Long.valueOf(props.get(ContentStore.CONTENT_SIZE));
 
-             // DEBUG REMOVE
+            // DEBUG REMOVE
             // long start = System.currentTimeMillis();
             Content content = dcStore.getContent(getSpaceID(group), getContentPrefix(group) + id);
             // DEBUG REMOVE
@@ -91,7 +91,7 @@ public class DuraCloudObjectStore implements ObjectStore
             Utils.copy(in, out);
             in.close();
             out.close();
-             // DEBUG REMOVE
+            // DEBUG REMOVE
             // elapsed = System.currentTimeMillis() - start;
             //System.out.println("DC fetch download: " + elapsed);
         }

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -74,22 +74,25 @@ public class DuraCloudObjectStore implements ObjectStore
         long size = 0L;
         try
         {
+            java.util.Map<String, String> props =
+                dcStore.getContentProperties(getSpaceID(group), getContentPrefix(group) + id);
+            size = Long.valueOf(props.get(ContentStore.CONTENT_SIZE));
+
              // DEBUG REMOVE
-            long start = System.currentTimeMillis();
+            // long start = System.currentTimeMillis();
             Content content = dcStore.getContent(getSpaceID(group), getContentPrefix(group) + id);
             // DEBUG REMOVE
-            long elapsed = System.currentTimeMillis() - start;
+            // long elapsed = System.currentTimeMillis() - start;
             //System.out.println("DC fetch content: " + elapsed);
-            size = Long.valueOf(content.getProperties().get(ContentStore.CONTENT_SIZE));
             FileOutputStream out = new FileOutputStream(file);
             // DEBUG remove
-            start = System.currentTimeMillis();
+            // start = System.currentTimeMillis();
             InputStream in = content.getStream();
             Utils.copy(in, out);
             in.close();
             out.close();
              // DEBUG REMOVE
-            elapsed = System.currentTimeMillis() - start;
+            // elapsed = System.currentTimeMillis() - start;
             //System.out.println("DC fetch download: " + elapsed);
         }
         catch (NotFoundException nfE)

--- a/src/main/java/org/dspace/pack/bagit/CollectionPacker.java
+++ b/src/main/java/org/dspace/pack/bagit/CollectionPacker.java
@@ -103,7 +103,7 @@ public class CollectionPacker implements Packer
         Bitstream logo = collection.getLogo();
         if (logo != null)
         {
-            bag.addData("logo", logo.getSize(), bitstreamService.retrieve(Curator.curationContext(), logo));
+            bag.addData("logo", logo.getSizeBytes(), bitstreamService.retrieve(Curator.curationContext(), logo));
         }
         bag.close();
         File archive = bag.deflate(archFmt);
@@ -147,7 +147,7 @@ public class CollectionPacker implements Packer
         Bitstream logo = collection.getLogo();
         if (logo != null)
         {
-            size += logo.getSize();
+            size += logo.getSizeBytes();
         }
         // proceed to items, unless 'norecurse' set
         if (! "norecurse".equals(method))

--- a/src/main/java/org/dspace/pack/bagit/CommunityPacker.java
+++ b/src/main/java/org/dspace/pack/bagit/CommunityPacker.java
@@ -97,7 +97,7 @@ public class CommunityPacker implements Packer
         Bitstream logo = community.getLogo();
         if (logo != null)
         {
-            bag.addData("logo", logo.getSize(), bitstreamService.retrieve(Curator.curationContext(), logo));
+            bag.addData("logo", logo.getSizeBytes(), bitstreamService.retrieve(Curator.curationContext(), logo));
         }
         bag.close();
         File archive = bag.deflate(archFmt);
@@ -140,7 +140,7 @@ public class CommunityPacker implements Packer
         Bitstream logo = community.getLogo();
         if (logo != null)
         {
-            size += logo.getSize();
+            size += logo.getSizeBytes();
         }
         // proceed to children, unless 'norecurse' set
         if (! "norecurse".equals(method))

--- a/src/main/java/org/dspace/pack/bagit/ItemPacker.java
+++ b/src/main/java/org/dspace/pack/bagit/ItemPacker.java
@@ -142,12 +142,12 @@ public class ItemPacker implements Packer
                     if (url != null)
                     {
                         // add reference to bag
-                        bag.addDataRef(relPath + seqId, bs.getSize(), url);
+                        bag.addDataRef(relPath + seqId, bs.getSizeBytes(), url);
                     }
                     else
                     {
                         // add bytes to bag
-                        bag.addData(relPath + seqId, bs.getSize(), bitstreamService.retrieve(Curator.curationContext(), bs));
+                        bag.addData(relPath + seqId, bs.getSizeBytes(), bitstreamService.retrieve(Curator.curationContext(), bs));
                     }
                 }
             }
@@ -260,7 +260,7 @@ public class ItemPacker implements Packer
             {
                 for (Bitstream bs : bundle.getBitstreams())
                 {
-                    size += bs.getSize();
+                    size += bs.getSizeBytes();
                 }
             }
         }
@@ -304,7 +304,7 @@ public class ItemPacker implements Packer
         for (RefFilter filter : refFilters)
         {
             if (filter.bundle.equals(bundle.getName()) &&
-                filter.size == bs.getSize())
+                filter.size == bs.getSizeBytes())
             {
                 return filter.url;
             }

--- a/src/main/java/org/dspace/pack/mets/METSPacker.java
+++ b/src/main/java/org/dspace/pack/mets/METSPacker.java
@@ -353,7 +353,7 @@ public class METSPacker implements Packer
         Bitstream logo = community.getLogo();
         if (logo != null)
         {
-            size += logo.getSize();
+            size += logo.getSizeBytes();
         }
         for (Community comm : community.getSubcommunities())
         {
@@ -383,7 +383,7 @@ public class METSPacker implements Packer
         Bitstream logo = collection.getLogo();
         if (logo != null)
         {
-            size += logo.getSize();
+            size += logo.getSizeBytes();
         }
         Iterator<Item> itemIter = itemService.findByCollection(Curator.curationContext(), collection);
         while (itemIter.hasNext())
@@ -412,7 +412,7 @@ public class METSPacker implements Packer
             {
                 for (Bitstream bs : bundle.getBitstreams())
                 {
-                    size += bs.getSize();
+                    size += bs.getSizeBytes();
                 }
             }
         }


### PR DESCRIPTION
Works with dspace 6.4 and 7.0 dspace-api (6.4+ specified in pom.xml)

Updated to use DuraCloud storeclient version 6.0.1 

String matching on configuration properties updated so that replicate-mets.xml settings have the desired effect.

Transfer file size retrieved using HEAD request (previously the missing CONTENT-LENGTH header in GET requests caused null value error).