### PR TITLE
[DS-4312] New reporting and skip options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <!-- DSpace Version Information (supported version of DSpace) -->
         <dspace.version>[6.0,6.3)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
-        <duracloud.version>4.2.5</duracloud.version>
+        <duracloud.version>6.0.0</duracloud.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <packaging>jar</packaging>
     <name>DSpace Replication Task Suite</name>
     <url>https://wiki.duraspace.org/display/DSPACE/ReplicationTaskSuite</url>
-    <version>6.1-SNAPSHOT</version>
+    <version>6.0.1</version>
 
     <organization>
         <name>DuraSpace</name>
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>[6.0,7.0)</dspace.version>
+        <dspace.version>6.3</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>4.2.5</duracloud.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <packaging>jar</packaging>
     <name>DSpace Replication Task Suite</name>
     <url>https://wiki.duraspace.org/display/DSPACE/ReplicationTaskSuite</url>
-    <version>6.0.1</version>
+    <version>6.0</version>
 
     <organization>
         <name>DuraSpace</name>
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>6.3</dspace.version>
+        <dspace.version>[6.0,6.3)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>4.2.5</duracloud.version>
     </properties>

--- a/src/main/java/org/dspace/ctask/replicate/AbstractPackagerTask.java
+++ b/src/main/java/org/dspace/ctask/replicate/AbstractPackagerTask.java
@@ -74,11 +74,13 @@ public abstract class AbstractPackagerTask extends AbstractCurationTask
             //loop through all properties in the config file
             for(String property : moduleProps)
             {
+                String propertyName = property.replace(moduleName + ".", "");
+
                 //Only obey the setting(s) beginning with this task's ID/name,
-                if(property.startsWith(this.taskId))
+                if(propertyName.startsWith(this.taskId))
                 {
                     //Parse out the option name by removing the "[taskID]." from beginning of property
-                    String option = property.replace(taskId + ".", "");
+                    String option = propertyName.replace(taskId + ".", "");
                     String value = configurationService.getProperty(property);
 
                     //Check which option is being set

--- a/src/main/java/org/dspace/ctask/replicate/BagItReplaceWithAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/BagItReplaceWithAIP.java
@@ -75,7 +75,13 @@ public class BagItReplaceWithAIP extends AbstractCurationTask {
             int status = Curator.CURATE_FAIL;
             String result = null;
             String objId = repMan.storageId(dso.getHandle(), archFmt);
-            File archive = repMan.fetchObject(storeGroupName, objId);
+            File archive = null;
+            try {
+                repMan.fetchObject(storeGroupName, objId);
+            } catch (IOException ie) {
+                // report cause of the store exception
+                report(ie.getMessage());
+            }
             if (archive != null) 
             {
                 // clear object where necessary

--- a/src/main/java/org/dspace/ctask/replicate/METSReplicateConsumer.java
+++ b/src/main/java/org/dspace/ctask/replicate/METSReplicateConsumer.java
@@ -416,7 +416,7 @@ public class METSReplicateConsumer implements Consumer {
         {
             // either marks end of current deletion or is member of
             // enclosing one: ignore if latter
-            if (delObjId.equals(id))
+            if (delObjId != null && delObjId.equals(id))
             {
                 // determine owner and write out deletion catalog
                 if (Constants.COLLECTION == event.getSubjectType())

--- a/src/main/java/org/dspace/ctask/replicate/METSRestoreFromAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/METSRestoreFromAIP.java
@@ -182,7 +182,6 @@ public class METSRestoreFromAIP extends AbstractPackagerTask
                         {
                             String msg = "Not restored/replaced: Archive " + childRef + " was not found in Replica Store.";
                             report(msg);
-                            setResult(msg);
                             // Keep track of error count during recursion.
                             errorCount++;
                         }

--- a/src/main/java/org/dspace/ctask/replicate/METSRestoreFromAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/METSRestoreFromAIP.java
@@ -214,7 +214,6 @@ public class METSRestoreFromAIP extends AbstractPackagerTask
         } catch (IOException ie) {
             // report the error and let callers deal with the error count and status.
             report(ie.getMessage());
-            setResult(ie.getMessage());
             // TODO this is duplicate logging for when the task reporter is not available. There's probably a better
             // solution.
             log.error(ie);

--- a/src/main/java/org/dspace/ctask/replicate/ReplicaManager.java
+++ b/src/main/java/org/dspace/ctask/replicate/ReplicaManager.java
@@ -244,8 +244,10 @@ public class ReplicaManager {
     public File fetchObject(String group, String objId) throws IOException
     {
         //String repId = safeId(id) + "." + arFmt;
+        long size = 0L;
         File file = stage(group, objId);
-        long size = objStore.fetchObject(group, objId, file);
+        size = objStore.fetchObject(group, objId, file);
+
         if (size > 0L)
         {
             synchronized (odoLock)

--- a/src/main/java/org/dspace/ctask/replicate/ReplicaManager.java
+++ b/src/main/java/org/dspace/ctask/replicate/ReplicaManager.java
@@ -258,7 +258,7 @@ public class ReplicaManager {
         return file.exists() ? file : null;
     }
     
-    public void transferObject(String group, File file) throws IOException {
+    public long transferObject(String group, File file) throws IOException {
         String psStr = objStore.objectAttribute(group, file.getName(), "sizebytes");
         long prevSize = psStr != null ? Long.valueOf(psStr) : 0L;
         long size = objStore.transferObject(group, file);
@@ -272,7 +272,8 @@ public class ReplicaManager {
                 }
                 odometer.save();
             }
-        }       
+        }
+        return size;
     }
     
     public boolean objectExists(String group, String objId) throws IOException {

--- a/src/main/java/org/dspace/ctask/replicate/TransmitAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/TransmitAIP.java
@@ -71,9 +71,9 @@ public class TransmitAIP extends AbstractCurationTask
             List<String> skipIds = createSkipList(skipList);
             for (String id : skipIds) {
                 if (id.trim().contentEquals(dso.getHandle())) {
-                    String msg = "SKIP-LIST: This item is in the replicate skiplist: " + dso.getHandle();
-                    report(msg);
+                    String msg = "This item is in the replicate skiplist: " + dso.getHandle();
                     setResult(msg);
+                    report(msg);
                     return Curator.CURATE_SKIP;
                 }
             }
@@ -94,8 +94,8 @@ public class TransmitAIP extends AbstractCurationTask
                 report(result);
                 return Curator.CURATE_UNSET;
             }
-            // File was not transmitted to DuraCloud (because the checksums matched).
-            // For local object stores the size will always be non-zero.
+            // File was not transmitted to DuraCloud because the checksums matched.
+            // (For local object stores the size will always be non-zero.)
             else if (size == 0L) {
                 setResult("Checksum matched. New AIP was not transmitted for " + dso.getHandle());
                 return Curator.CURATE_SUCCESS;

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -78,7 +78,7 @@ public class DuraCloudObjectStore implements ObjectStore
                 dcStore.getContentProperties(getSpaceID(group), getContentPrefix(group) + id);
             size = Long.valueOf(props.get(ContentStore.CONTENT_SIZE));
 
-             // DEBUG REMOVE
+            // DEBUG REMOVE
             // long start = System.currentTimeMillis();
             Content content = dcStore.getContent(getSpaceID(group), getContentPrefix(group) + id);
             // DEBUG REMOVE
@@ -91,7 +91,7 @@ public class DuraCloudObjectStore implements ObjectStore
             Utils.copy(in, out);
             in.close();
             out.close();
-             // DEBUG REMOVE
+            // DEBUG REMOVE
             // elapsed = System.currentTimeMillis() - start;
             //System.out.println("DC fetch download: " + elapsed);
         }

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -7,11 +7,7 @@
  */
 package org.dspace.ctask.replicate.store;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -167,7 +163,8 @@ public class DuraCloudObjectStore implements ObjectStore
         }
         catch (ContentStoreException csE)
         {
-            throw new IOException(csE);
+            // Log the DuraCloud exception message for getContentProperties.
+            System.out.println(csE.getMessage());
         }
         // delete staging file
         file.delete();
@@ -192,12 +189,18 @@ public class DuraCloudObjectStore implements ObjectStore
                                new FileInputStream(file), file.length(),
                                mimeType, chkSum,
                                new HashMap<String, String>());
-        
             return file.length();
+
         }
         catch (ContentStoreException csE)
         {
-            throw new IOException(csE);
+            // Log the DuraCloud exception for addContent.
+            System.out.println(csE.getMessage());
+            // Setting to -1 causes the TransmitAip task to report the transmission error.
+            return -1;
+        }
+        catch (FileNotFoundException e) {
+            throw new IOException(e.getMessage());
         }
     }
 
@@ -262,7 +265,7 @@ public class DuraCloudObjectStore implements ObjectStore
      * If the group contains a forward slash ('/'), then the substring
      * before the first slash is assumed to be the Space ID.
      * Otherwise, the entire group name is assumed to be the Space ID.
-     * @param String group name
+     * @param group name
      * @return DuraCloud Space ID
      */
     private String getSpaceID(String group)
@@ -282,7 +285,7 @@ public class DuraCloudObjectStore implements ObjectStore
      * If the group contains a forward slash ('/'), then the substring
      * after the first slash is assumed to be the content naming prefix.
      * Otherwise, there is no content naming prefix.
-     * @param String group name
+     * @param group name
      * @return content prefix (ending with a forward slash)
      */
     private String getContentPrefix(String group)

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -74,22 +74,25 @@ public class DuraCloudObjectStore implements ObjectStore
         long size = 0L;
         try
         {
+            java.util.Map<String, String> props =
+                dcStore.getContentProperties(getSpaceID(group), getContentPrefix(group) + id);
+            size = Long.valueOf(props.get(ContentStore.CONTENT_SIZE));
+
              // DEBUG REMOVE
-            long start = System.currentTimeMillis();
+            // long start = System.currentTimeMillis();
             Content content = dcStore.getContent(getSpaceID(group), getContentPrefix(group) + id);
             // DEBUG REMOVE
-            long elapsed = System.currentTimeMillis() - start;
+            // long elapsed = System.currentTimeMillis() - start;
             //System.out.println("DC fetch content: " + elapsed);
-            size = Long.valueOf(content.getProperties().get(ContentStore.CONTENT_SIZE));
             FileOutputStream out = new FileOutputStream(file);
             // DEBUG remove
-            start = System.currentTimeMillis();
+            // start = System.currentTimeMillis();
             InputStream in = content.getStream();
             Utils.copy(in, out);
             in.close();
             out.close();
              // DEBUG REMOVE
-            elapsed = System.currentTimeMillis() - start;
+            // elapsed = System.currentTimeMillis() - start;
             //System.out.println("DC fetch download: " + elapsed);
         }
         catch (NotFoundException nfE)

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -163,8 +163,7 @@ public class DuraCloudObjectStore implements ObjectStore
         }
         catch (ContentStoreException csE)
         {
-            // Log the DuraCloud exception message for getContentProperties.
-            System.out.println(csE.getMessage());
+            throw new IOException(csE.getMessage());
         }
         // delete staging file
         file.delete();
@@ -195,10 +194,7 @@ public class DuraCloudObjectStore implements ObjectStore
         }
         catch (ContentStoreException csE)
         {
-            // Log the DuraCloud exception for addContent.
-            System.out.println(csE.getMessage());
-            // Setting to -1 causes the TransmitAip task to report the transmission error.
-            return -1;
+            throw new IOException(csE.getMessage());
         }
         catch (FileNotFoundException e) {
             throw new IOException(e.getMessage());

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -189,7 +189,8 @@ public class DuraCloudObjectStore implements ObjectStore
                                new FileInputStream(file), file.length(),
                                mimeType, chkSum,
                                new HashMap<String, String>());
-            return file.length();
+
+             return file.length();
 
         }
         catch (ContentStoreException csE)


### PR DESCRIPTION
This PR modifies the transmit and restore tasks to continue processing and report when an error occurs during transmission or when an object is missing from the archive (in the case of restore operations). 

Other types of errors (IOExceptions, SQLExceptions) still halt processing.  More review is probably needed to decide whether that's good or bad.

A "skip" configuration has been added to the transmitaip task (useful in the case of items that cannot be transmitted to DuraCloud due to file size limits, etc.). The new config option is in replicate.cfg: _replicate.transmitaip.skiplist_

The PR includes changes from an earlier bugfix PR  -- https://github.com/DSpace/dspace-replicate/pull/27


