### PR TITLE
Tell Travis to use Ubuntu Trusty 14.04 (3.x version)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 sudo: false
+dist: trusty
 jdk:
   - oraclejdk8
   - openjdk7


### PR DESCRIPTION
As Travis CI now defaults to using Ubuntu Xenial 16.04, this dspace-replicate project is failing to build. This is because Xenial does not support OracleJDK8 anymore (which is used by default for builds).

The fix is to tell Travis to continue to use Ubuntu Trust 14.04. This same issue occurred in the main DSpace/DSpace repo, see DSpace/DSpace#2477

These changes were also applied to master in #33 