### PR TITLE
Clarifies DSpace versions supported on the 3_x branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>[3.0,6.0)</dspace.version>
+        <dspace.version>[3.0,4.20)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>4.3.9</duracloud.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>[3.0,4.0)</dspace.version>
+        <dspace.version>[3.0,6.0)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>4.3.9</duracloud.version>
     </properties>


### PR DESCRIPTION
Updates dspace.version property to include DSpace 3.x, 4.x, and 5.x