### PR TITLE
DS 4329b: Do not assume "content-length" header is returned from DuraCloud (master version)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <!-- DSpace Version Information (supported version of DSpace) -->
         <dspace.version>[6.0,7.0)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
-        <duracloud.version>4.2.5</duracloud.version>
+        <duracloud.version>6.1.1</duracloud.version>
     </properties>
 
     <build>

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -74,13 +74,7 @@ public class DuraCloudObjectStore implements ObjectStore
         long size = 0L;
         try
         {
-            // DEBUG REMOVE
-            //long start = System.currentTimeMillis();
-
             Content content = dcStore.getContent(getSpaceID(group), getContentPrefix(group) + id);
-            // DEBUG REMOVE
-            //long elapsed = System.currentTimeMillis() - start;
-            //System.out.println("DC fetch content: " + elapsed);
 
             // Attempt to get size from request header
             String contentSizeHeader = content.getProperties().get(ContentStore.CONTENT_SIZE);
@@ -91,19 +85,12 @@ public class DuraCloudObjectStore implements ObjectStore
                 // ignore - header was missing or not a valid Long. We will determine size below
             }
 
-            // DEBUG remove
-            // start = System.currentTimeMillis();
-
             // Open local file and download content into it
             FileOutputStream out = new FileOutputStream(file);
             InputStream in = content.getStream();
             Utils.copy(in, out);
             in.close();
             out.close();
-
-            // DEBUG REMOVE
-            //elapsed = System.currentTimeMillis() - start;
-            //System.out.println("DC fetch download: " + elapsed);
 
             // If size could not be previously determined from request header, determine it from the downloaded file
             if (size == 0L) {


### PR DESCRIPTION
Replacement for: https://github.com/DSpace/dspace-replicate/pull/32.

I tested #32 and added commits to update DuraCloud version and remove debugging.