### PR TITLE
DS 4329b: Do not assume "content-length" header is returned from DuraCloud (RTS v5 version)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <!-- DSpace Version Information (supported version of DSpace) -->
         <dspace.version>[5.0,5.20)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
-        <duracloud.version>4.3.9</duracloud.version>
+        <duracloud.version>6.1.1</duracloud.version>
     </properties>
 
     <build>

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -70,14 +70,7 @@ public class DuraCloudObjectStore implements ObjectStore
         long size = 0L;
         try
         {
-            // DEBUG REMOVE
-            //long start = System.currentTimeMillis();
-
             Content content = dcStore.getContent(getSpaceID(group), getContentPrefix(group) + id);
-
-            // DEBUG REMOVE
-            //long elapsed = System.currentTimeMillis() - start;
-            //System.out.println("DC fetch content: " + elapsed);
 
             // Attempt to get size from request header
             String contentSizeHeader = content.getProperties().get(ContentStore.CONTENT_SIZE);
@@ -88,19 +81,12 @@ public class DuraCloudObjectStore implements ObjectStore
                 // ignore - header was missing or not a valid Long. We will determine size below
             }
 
-            // DEBUG remove
-            //start = System.currentTimeMillis();
-
             // Open local file and download content into it
             FileOutputStream out = new FileOutputStream(file);
             InputStream in = content.getStream();
             Utils.copy(in, out);
             in.close();
             out.close();
-
-            // DEBUG REMOVE
-            //elapsed = System.currentTimeMillis() - start;
-            //System.out.println("DC fetch download: " + elapsed);
 
             // If size could not be previously determined from request header, determine it from the downloaded file
             if (size == 0L) {

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -37,7 +37,7 @@ public class DuraCloudObjectStore implements ObjectStore
 {
     // DuraCloud store
     private ContentStore dcStore = null;
-    
+
     public DuraCloudObjectStore()
     {
     }
@@ -50,16 +50,16 @@ public class DuraCloudObjectStore implements ObjectStore
             new ContentStoreManagerImpl(localProperty("host"),
                                         localProperty("port"),
                                         localProperty("context"));
-        Credential credential = 
+        Credential credential =
             new Credential(localProperty("username"), localProperty("password"));
         storeManager.login(credential);
         try
         {
-            //Get the primary content store (e.g. Amazon)   
+            //Get the primary content store (e.g. Amazon)
             dcStore = storeManager.getPrimaryContentStore();
         }
         catch (ContentStoreException csE)
-        {      
+        {
             throw new IOException("Unable to connect to the DuraCloud Primary Content Store. Please check the DuraCloud connection/authentication settings in your 'duracloud.cfg' file.", csE);
         }
     }
@@ -70,23 +70,42 @@ public class DuraCloudObjectStore implements ObjectStore
         long size = 0L;
         try
         {
-             // DEBUG REMOVE
-            long start = System.currentTimeMillis();
-            Content content = dcStore.getContent(getSpaceID(group), getContentPrefix(group) + id);
             // DEBUG REMOVE
-            long elapsed = System.currentTimeMillis() - start;
+            //long start = System.currentTimeMillis();
+
+            Content content = dcStore.getContent(getSpaceID(group), getContentPrefix(group) + id);
+
+            // DEBUG REMOVE
+            //long elapsed = System.currentTimeMillis() - start;
             //System.out.println("DC fetch content: " + elapsed);
-            size = Long.valueOf(content.getProperties().get(ContentStore.CONTENT_SIZE));
-            FileOutputStream out = new FileOutputStream(file);
+
+            // Attempt to get size from request header
+            String contentSizeHeader = content.getProperties().get(ContentStore.CONTENT_SIZE);
+            try {
+                size = Long.valueOf(contentSizeHeader);
+            }
+            catch(NumberFormatException nfe) {
+                // ignore - header was missing or not a valid Long. We will determine size below
+            }
+
             // DEBUG remove
-            start = System.currentTimeMillis();
+            //start = System.currentTimeMillis();
+
+            // Open local file and download content into it
+            FileOutputStream out = new FileOutputStream(file);
             InputStream in = content.getStream();
             Utils.copy(in, out);
             in.close();
             out.close();
-             // DEBUG REMOVE
-            elapsed = System.currentTimeMillis() - start;
+
+            // DEBUG REMOVE
+            //elapsed = System.currentTimeMillis() - start;
             //System.out.println("DC fetch download: " + elapsed);
+
+            // If size could not be previously determined from request header, determine it from the downloaded file
+            if (size == 0L) {
+                size = file.length();
+            }
         }
         catch (NotFoundException nfE)
         {
@@ -98,7 +117,7 @@ public class DuraCloudObjectStore implements ObjectStore
         }
         return size;
     }
-    
+
     @Override
     public boolean objectExists(String group, String id) throws IOException
     {
@@ -171,7 +190,7 @@ public class DuraCloudObjectStore implements ObjectStore
     {
         try
         {
-            //@TODO: We shouldn't need to pass a hardcoded MIME Type. Unfortunately, DuraCloud, 
+            //@TODO: We shouldn't need to pass a hardcoded MIME Type. Unfortunately, DuraCloud,
             // as of 1.3, doesn't properly determine a file's MIME Type. In future it should.
             String mimeType = "application/octet-stream";
             if(file.getName().endsWith(".zip"))
@@ -180,12 +199,12 @@ public class DuraCloudObjectStore implements ObjectStore
                 mimeType = "application/x-gzip";
             else if(file.getName().endsWith(".txt"))
                 mimeType = "text/plain";
-            
+
             dcStore.addContent(getSpaceID(group), getContentPrefix(group) + file.getName(),
                                new FileInputStream(file), file.length(),
                                mimeType, chkSum,
                                new HashMap<String, String>());
-        
+
             return file.length();
         }
         catch (ContentStoreException csE)
@@ -203,7 +222,7 @@ public class DuraCloudObjectStore implements ObjectStore
         {
             Map<String, String> attrs = dcStore.getContentProperties(getSpaceID(srcGroup), getContentPrefix(srcGroup) + id);
             size = Long.valueOf(attrs.get(ContentStore.CONTENT_SIZE));
-            dcStore.moveContent(getSpaceID(srcGroup), getContentPrefix(srcGroup) + id, 
+            dcStore.moveContent(getSpaceID(srcGroup), getContentPrefix(srcGroup) + id,
                                 getSpaceID(destGroup), getContentPrefix(destGroup) + id);
         }
         catch (NotFoundException nfE)
@@ -216,14 +235,14 @@ public class DuraCloudObjectStore implements ObjectStore
         }
         return size;
     }
-    
+
     @Override
     public String objectAttribute(String group, String id, String attrName) throws IOException
     {
         try
         {
             Map<String, String> attrs = dcStore.getContentProperties(getSpaceID(group), getContentPrefix(group) + id);
-            
+
             if ("checksum".equals(attrName))
             {
                 return attrs.get(ContentStore.CONTENT_CHECKSUM);
@@ -247,12 +266,12 @@ public class DuraCloudObjectStore implements ObjectStore
             throw new IOException(csE);
         }
     }
-    
+
     private static String localProperty(String name)
     {
         return ConfigurationManager.getProperty("duracloud", name);
     }
-    
+
     /**
      * Returns the Space ID where content should be stored in DuraCloud,
      * based on the passed in Group.
@@ -272,7 +291,7 @@ public class DuraCloudObjectStore implements ObjectStore
         else // otherwise, the passed in group is the Space ID
             return group;
     }
-    
+
     /**
      * Returns the Content prefix that should be used when saving a file
      * to a DuraCloud space.


### PR DESCRIPTION
Companion PR to #31 for RTS 5.x.

Tested on a DSpace 5.10 instance.