### PR TITLE
Adds support for reading package parameters when a leading module name is present

### DIFF
--- a/config/modules/replicate-mets.cfg
+++ b/config/modules/replicate-mets.cfg
@@ -28,9 +28,10 @@
 #         This corresponds to '--all' option of AIP Backup & Restore tool.
 #    * all ingest packager options available in the current AIP Backup & Restore feature:
 #      See documentation at: 
-#      https://wiki.duraspace.org/display/DSDOC18/AIP+Backup+and+Restore#AIPBackupandRestore-AdditionalPackagerOptions
+#      https://wiki.lyrasis.org/display/DSDOC6x/AIP+Backup+and+Restore#AIPBackupandRestore-AdditionalPackagerOptions
 #
-# SETTING FORMAT: [taskname].[option] = [value]
+# SETTING FORMAT: [modulename].[taskname].[option] = [value]
+# * [modulename] = name of this module
 # * [taskname] = name of the task, as defined in curate.cfg
 # * [option] = an option name as described above
 # * [value] = an option value as described above

--- a/src/main/java/org/dspace/ctask/replicate/AbstractPackagerTask.java
+++ b/src/main/java/org/dspace/ctask/replicate/AbstractPackagerTask.java
@@ -81,7 +81,7 @@ public abstract class AbstractPackagerTask extends AbstractCurationTask
                 //Set propertyName, removing leading module name (if applicable)
                 String propertyName = property;
                 if(propertyName.startsWith(moduleName + ".")) {
-                    propertyName = property.replaceFirst(moduleName + ".", "");
+                    propertyName = propertyName.replaceFirst(moduleName + ".", "");
                 }
 
                 //Only obey the setting(s) beginning with this task's ID/name,


### PR DESCRIPTION
Required due to the addition of module names as a prefix to property elements in DSpace 6.x


