### PR TITLE
DS-1999 - Ensure AIP exists in remote storage before creating a DELETION_RECORD

### DIFF
--- a/src/main/java/org/dspace/ctask/replicate/BagItReplicateConsumer.java
+++ b/src/main/java/org/dspace/ctask/replicate/BagItReplicateConsumer.java
@@ -49,7 +49,7 @@ import static org.dspace.event.Event.*;
 /**
  * BagItReplicateConsumer is an event consumer that tracks events relevant to
  * replication synchronization. In response to deletions, it creates and
- * transmits a catalog of deleted objects (so they may be restored if 
+ * transmits a catalog of deleted objects (so they may be restored if
  * deletion was an error). For new or changed objects, it queues a request
  * to perform the configured curation tasks, or directly performs the task
  * if so indicated.
@@ -91,7 +91,7 @@ public class BagItReplicateConsumer implements Consumer {
     // create deletion catalogs?
     private boolean catalogDeletes = false;
     // Group where all AIPs are stored
-    private final String storeGroupName = ConfigurationManager.getProperty("replicate", "group.aip.name");
+    private final String storeGroupName = configurationService.getProperty("replicate.group.aip.name");
     // Group where object deletion catalog/records are stored
     private final String deleteGroupName = configurationService.getProperty("replicate.group.delete.name");
 
@@ -495,7 +495,7 @@ public class BagItReplicateConsumer implements Consumer {
                     {
                         modQTasks = new ArrayList<String>();
                     }
-                    modQTasks.add(task);   
+                    modQTasks.add(task);
                 }
                 else if ("del".equals(propName))
                 {
@@ -503,12 +503,12 @@ public class BagItReplicateConsumer implements Consumer {
                     {
                         delTasks = new ArrayList<String>();
                     }
-                    delTasks.add(task);   
+                    delTasks.add(task);
                 }
             }
             //Otherwise (if the task ends in "+p"),
             //  it should be added to the list of tasks to perform immediately
-            else 
+            else
             {
                 String sTask = task.substring(0, task.lastIndexOf("+p"));
                 if ("add".equals(propName))
@@ -533,7 +533,7 @@ public class BagItReplicateConsumer implements Consumer {
                     if ("catalog".equals(sTask))
                     {
                         catalogDeletes = true;
-                    } 
+                    }
                 }
             }
         }

--- a/src/main/java/org/dspace/ctask/replicate/BagItReplicateConsumer.java
+++ b/src/main/java/org/dspace/ctask/replicate/BagItReplicateConsumer.java
@@ -53,7 +53,7 @@ import static org.dspace.event.Event.*;
  * deletion was an error). For new or changed objects, it queues a request
  * to perform the configured curation tasks, or directly performs the task
  * if so indicated.
- * 
+ *
  * @author richardrodgers
  */
 public class BagItReplicateConsumer implements Consumer {
@@ -90,6 +90,8 @@ public class BagItReplicateConsumer implements Consumer {
     private List<String> delTasks = null;
     // create deletion catalogs?
     private boolean catalogDeletes = false;
+    // Group where all AIPs are stored
+    private final String storeGroupName = ConfigurationManager.getProperty("replicate", "group.aip.name");
     // Group where object deletion catalog/records are stored
     private final String deleteGroupName = configurationService.getProperty("replicate.group.delete.name");
 
@@ -238,7 +240,7 @@ public class BagItReplicateConsumer implements Consumer {
             }
             taskPMap.clear();
         }
-       
+
         // if there any uncommitted deletions, record them now
         if (delObjId != null)
         {
@@ -355,24 +357,33 @@ public class BagItReplicateConsumer implements Consumer {
         // write out deletion catalog if defined
         if (catalogDeletes)
         {
-            Packer packer = new CatalogPacker(delObjId, delOwnerId, delMemIds);
-            try
+            //First, check if this object has an AIP in storage
+            boolean found = repMan.objectExists(storeGroupName, delObjId);
+
+            // If the object has an AIP, then create a deletion catalog
+            // If there's no AIP, then there's no need for a deletion
+            // catalog as the object isn't backed up & cannot be restored!
+            if(found)
             {
-                // Create a new deletion catalog (with default file extension / format)
-                // and store it in the deletion group store
-                String catID = repMan.deletionCatalogId(delObjId, null);
-                File packDir = repMan.stage(deleteGroupName, catID);
-                File archive = packer.pack(packDir);
-                //System.out.println("delcat about to transfer");
-                repMan.transferObject(deleteGroupName, archive);
-            }
-            catch (AuthorizeException authE)
-            {
-                throw new IOException(authE);
-            }
-            catch (SQLException sqlE)
-            {
-                throw new IOException(sqlE);
+                Packer packer = new CatalogPacker(delObjId, delOwnerId, delMemIds);
+                try
+                {
+                    // Create a new deletion catalog (with default file extension / format)
+                    // and store it in the deletion group store
+                    String catID = repMan.deletionCatalogId(delObjId, null);
+                    File packDir = repMan.stage(deleteGroupName, catID);
+                    File archive = packer.pack(packDir);
+                    //System.out.println("delcat about to transfer");
+                    repMan.transferObject(deleteGroupName, archive);
+                }
+                catch (AuthorizeException authE)
+                {
+                    throw new IOException(authE);
+                }
+                catch (SQLException sqlE)
+                {
+                    throw new IOException(sqlE);
+                }
             }
         }
         // reset for next events
@@ -450,7 +461,7 @@ public class BagItReplicateConsumer implements Consumer {
             }
         }
     }
-    
+
     /**
      * Parse the list of Consumer tasks to perform.  This list of tasks
      * is in the 'replicate.cfg' file.

--- a/src/main/java/org/dspace/ctask/replicate/METSReplicateConsumer.java
+++ b/src/main/java/org/dspace/ctask/replicate/METSReplicateConsumer.java
@@ -104,7 +104,7 @@ public class METSReplicateConsumer implements Consumer {
     // create deletion catalogs?
     private boolean catalogDeletes = false;
     // Group where all AIPs are stored
-    private final String storeGroupName = ConfigurationManager.getProperty("replicate", "group.aip.name");
+    private final String storeGroupName = configurationService.getProperty("replicate.group.aip.name");
     // Group where object deletion catalog/records are stored
     private final String deleteGroupName = configurationService.getProperty("replicate.group.delete.name");
 
@@ -600,7 +600,7 @@ public class METSReplicateConsumer implements Consumer {
                     {
                         modQTasks = new ArrayList<String>();
                     }
-                    modQTasks.add(task);   
+                    modQTasks.add(task);
                 }
                 else if ("del".equals(propName))
                 {
@@ -608,12 +608,12 @@ public class METSReplicateConsumer implements Consumer {
                     {
                         delTasks = new ArrayList<String>();
                     }
-                    delTasks.add(task);   
+                    delTasks.add(task);
                 }
             }
             //Otherwise (if the task ends in "+p"),
             //  it should be added to the list of tasks to perform immediately
-            else 
+            else
             {
                 String sTask = task.substring(0, task.lastIndexOf("+p"));
                 if ("add".equals(propName))
@@ -638,7 +638,7 @@ public class METSReplicateConsumer implements Consumer {
                     if ("catalog".equals(sTask))
                     {
                         catalogDeletes = true;
-                    } 
+                    }
                 }
             }
         }

--- a/src/main/java/org/dspace/ctask/replicate/METSReplicateConsumer.java
+++ b/src/main/java/org/dspace/ctask/replicate/METSReplicateConsumer.java
@@ -64,7 +64,7 @@ import static org.dspace.event.Event.*;
  * # consumer to manage content replication (Replication Task Suite add-on)
  * event.consumer.replicate.class = org.dspace.ctask.replicate.METSReplicateConsumer
  * event.consumer.replicate.filters = Community|Collection|Item|Group|EPerson+All
- * 
+ *
  * @author tdonohue
  * @author richardrodgers
  */
@@ -103,6 +103,8 @@ public class METSReplicateConsumer implements Consumer {
     private List<String> delTasks = null;
     // create deletion catalogs?
     private boolean catalogDeletes = false;
+    // Group where all AIPs are stored
+    private final String storeGroupName = ConfigurationManager.getProperty("replicate", "group.aip.name");
     // Group where object deletion catalog/records are stored
     private final String deleteGroupName = configurationService.getProperty("replicate.group.delete.name");
 
@@ -269,7 +271,7 @@ public class METSReplicateConsumer implements Consumer {
                         }
                     }
                     break;
-                
+
                 case REMOVE: //REMOVE = Remove an object from a container or group
                 case DELETE: //DELETE = Delete an object (actually destroy it)
                     // For REMOVE & DELETE, the Handle of object being deleted is found in Event Detail
@@ -327,7 +329,7 @@ public class METSReplicateConsumer implements Consumer {
             }
             taskPMap.clear();
         }
-       
+
         // if there any uncommitted deletions, record them now
         if (delObjId != null)
         {
@@ -459,25 +461,34 @@ public class METSReplicateConsumer implements Consumer {
         // write out deletion catalog if defined
         if (catalogDeletes)
         {
-            //Create a deletion catalog (in BagIt format) of all deleted objects
-            Packer packer = new CatalogPacker(delObjId, delOwnerId, delMemIds);
-            try
+            //First, check if this object has an AIP in storage
+            boolean found = repMan.objectExists(storeGroupName, delObjId);
+
+            // If the object has an AIP, then create a deletion catalog
+            // If there's no AIP, then there's no need for a deletion
+            // catalog as the object isn't backed up & cannot be restored!
+            if(found)
             {
-                // Create a new deletion catalog (with default file extension / format)
-                // and store it in the deletion group store
-                String catID = repMan.deletionCatalogId(delObjId, null);
-                File packDir = repMan.stage(deleteGroupName, catID);
-                File archive = packer.pack(packDir);
-                // Create a deletion catalog in deletion archive location.
-                repMan.transferObject(deleteGroupName, archive);
-            }
-            catch (AuthorizeException authE)
-            {
-                throw new IOException(authE);
-            }
-            catch (SQLException sqlE)
-            {
-                throw new IOException(sqlE);
+                //Create a deletion catalog (in BagIt format) of all deleted objects
+                Packer packer = new CatalogPacker(delObjId, delOwnerId, delMemIds);
+                try
+                {
+                    // Create a new deletion catalog (with default file extension / format)
+                    // and store it in the deletion group store
+                    String catID = repMan.deletionCatalogId(delObjId, null);
+                    File packDir = repMan.stage(deleteGroupName, catID);
+                    File archive = packer.pack(packDir);
+                    // Create a deletion catalog in deletion archive location.
+                    repMan.transferObject(deleteGroupName, archive);
+                }
+                catch (AuthorizeException authE)
+                {
+                    throw new IOException(authE);
+                }
+                catch (SQLException sqlE)
+                {
+                    throw new IOException(sqlE);
+                }
             }
         }
         // reset for next events
@@ -555,7 +566,7 @@ public class METSReplicateConsumer implements Consumer {
             }
         }
     }
-    
+
     /**
      * Parse the list of Consumer tasks to perform.  This list of tasks
      * is in the 'replicate.cfg' file.


### PR DESCRIPTION
Updates https://github.com/DSpace/dspace-replicate/pull/12 with a rebase on master and minor fixes to bring it up to speed. Original description:

Fixes DS-1999. First checks to see if the AIP exists in remote storage (backup storage) before any DELETION_RECORD catalog file is written. If the AIP does not exist, then the DELETION_RECORD is not created, as the object was never backed up.

https://jira.duraspace.org/browse/DS-1999