### PR TITLE
Update RTS for DSpace 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+jdk: oraclejdk11
 sudo: false
 dist: trusty
 script: mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,20 @@
         <url>http://www.dspace.org</url>
     </organization>
 
+    <!--
+    A Parent POM that Maven inherits DSpace Defaults
+    POM attributes from.
+    -->
+    <parent>
+        <groupId>org.dspace</groupId>
+        <artifactId>modules</artifactId>
+        <version>7.0-beta5-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>[7.0-beta2.1,7.0)</dspace.version>
+        <dspace.version>7.0-beta5-SNAPSHOT</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>6.1.1</duracloud.version>
         <!-- DuraSpace BagIt Support Library -->
@@ -247,7 +258,6 @@
         <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
-          <version>4.13</version>
           <scope>test</scope>
         </dependency>
         <dependency>
@@ -259,8 +269,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.1.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.duraspace</groupId>
@@ -274,6 +289,14 @@
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tika</groupId>
+                    <artifactId>tika-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -324,6 +347,10 @@
                 <exclusion>
                  <groupId>ch.qos.logback</groupId>
                  <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-xc</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <description>Replication Task Suite: A DSpace add-on providing Curation Tasks that perform replication
      (backup and restore) of DSpace content to other locations or services.</description>
     <url>https://wiki.lyrasis.org/display/DSPACE/ReplicationTaskSuite</url>
-    <version>6.2-SNAPSHOT</version>
+    <version>7.0-SNAPSHOT</version>
 
     <organization>
         <name>LYRASIS</name>
@@ -16,7 +16,7 @@
 
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>[6.0,6.20)</dspace.version>
+        <dspace.version>[7.0-beta2.1,7.0)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>6.1.1</duracloud.version>
         <!-- DuraSpace BagIt Support Library -->
@@ -259,7 +259,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.28.2</version>
+            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/dspace/ctask/replicate/METSRestoreFromAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/METSRestoreFromAIP.java
@@ -100,7 +100,7 @@ public class METSRestoreFromAIP extends AbstractPackagerTask
             //Load packaging options from replicate-mets.cfg configuration file
             PackageParameters pkgParams = this.loadPackagerParameters(metsModuleConfig);
             if (scope == null) {
-                scope = "*";
+                scope = "";
             }
             pkgParams.setProperty("scope", scope);
             

--- a/src/main/java/org/dspace/ctask/replicate/checkm/TransmitManifest.java
+++ b/src/main/java/org/dspace/ctask/replicate/checkm/TransmitManifest.java
@@ -294,7 +294,7 @@ public class TransmitManifest extends AbstractCurationTask {
                                 break;
                             case 3:
                                 // length
-                                sb.append(bs.getSize());
+                                sb.append(bs.getSizeBytes());
                                 break;
                             case 4:
                                 // modified - use item level data?

--- a/src/main/java/org/dspace/pack/bagit/CollectionPacker.java
+++ b/src/main/java/org/dspace/pack/bagit/CollectionPacker.java
@@ -162,7 +162,7 @@ public class CollectionPacker implements Packer
         Bitstream logo = collection.getLogo();
         if (logo != null)
         {
-            size += logo.getSize();
+            size += logo.getSizeBytes();
         }
         // proceed to items, unless 'norecurse' set
         if (! "norecurse".equals(method))

--- a/src/main/java/org/dspace/pack/bagit/CommunityPacker.java
+++ b/src/main/java/org/dspace/pack/bagit/CommunityPacker.java
@@ -158,7 +158,7 @@ public class CommunityPacker implements Packer
         Bitstream logo = community.getLogo();
         if (logo != null)
         {
-            size += logo.getSize();
+            size += logo.getSizeBytes();
         }
         // proceed to children, unless 'norecurse' set
         if (! "norecurse".equals(method))

--- a/src/main/java/org/dspace/pack/bagit/ItemPacker.java
+++ b/src/main/java/org/dspace/pack/bagit/ItemPacker.java
@@ -242,7 +242,7 @@ public class ItemPacker implements Packer {
             {
                 for (Bitstream bs : bundle.getBitstreams())
                 {
-                    size += bs.getSize();
+                    size += bs.getSizeBytes();
                 }
             }
         }
@@ -286,7 +286,7 @@ public class ItemPacker implements Packer {
         for (RefFilter filter : refFilters)
         {
             if (filter.bundle.equals(bundle.getName()) &&
-                filter.size == bs.getSize())
+                filter.size == bs.getSizeBytes())
             {
                 return filter.url;
             }

--- a/src/main/java/org/dspace/pack/mets/METSPacker.java
+++ b/src/main/java/org/dspace/pack/mets/METSPacker.java
@@ -10,10 +10,7 @@ package org.dspace.pack.mets;
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
@@ -67,6 +64,9 @@ public class METSPacker implements Packer
     
     /** List of all referenced child packages **/
     private List<String> childPackageRefs = new ArrayList<String>();
+
+    /** List of all referenced related packages **/
+    private Map<String, List<String>> relPackageRefs = new HashMap<>();
     
     /** DSpace PackageDisseminator & PackageIngester to utilize for AIP pack() & unpack() **/
     private PackageDisseminator dip = null;
@@ -280,7 +280,9 @@ public class METSPacker implements Packer
             {
                 //Check if we found child package references when unpacking this latest package into a DSpaceObject
                 this.childPackageRefs = ((AbstractPackageIngester) sip).getPackageReferences(updatedDso);
-            }//end if not an Item
+            } else if (updatedDso != null && updatedDso.getType() == Constants.ITEM) {
+                this.relPackageRefs = ((AbstractPackageIngester) sip).getRelPackageReferences(updatedDso);
+            }
         } 
         
         //NOTE: Context is handled by Curator -- it will commit or close when needed.
@@ -460,5 +462,19 @@ public class METSPacker implements Packer
     public List<String> getChildPackageRefs()
     {
         return childPackageRefs;
+    }
+
+    /**
+     * Return list of referenced related packages (AIPs) which were
+     * located during the unpacking of an AIP (see unpack()).
+     * <P>
+     * This may be used by tasks so that they can recursively unpack()
+     * additional referenced child packages as needed.
+     *
+     * @return List of references to child AIPs
+     */
+    public Map<String, List<String>> getRelPackageRefs()
+    {
+        return relPackageRefs;
     }
 }

--- a/src/main/java/org/dspace/pack/mets/METSPacker.java
+++ b/src/main/java/org/dspace/pack/mets/METSPacker.java
@@ -353,7 +353,7 @@ public class METSPacker implements Packer
         Bitstream logo = community.getLogo();
         if (logo != null)
         {
-            size += logo.getSize();
+            size += logo.getSizeBytes();
         }
         for (Community comm : community.getSubcommunities())
         {
@@ -383,7 +383,7 @@ public class METSPacker implements Packer
         Bitstream logo = collection.getLogo();
         if (logo != null)
         {
-            size += logo.getSize();
+            size += logo.getSizeBytes();
         }
         Iterator<Item> itemIter = itemService.findByCollection(Curator.curationContext(), collection);
         while (itemIter.hasNext())
@@ -412,7 +412,7 @@ public class METSPacker implements Packer
             {
                 for (Bitstream bs : bundle.getBitstreams())
                 {
-                    size += bs.getSize();
+                    size += bs.getSizeBytes();
                 }
             }
         }

--- a/src/test/java/org/dspace/AbstractDSpaceTest.java
+++ b/src/test/java/org/dspace/AbstractDSpaceTest.java
@@ -1,0 +1,119 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace;
+
+import java.io.IOException;
+import java.net.URL;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.TimeZone;
+
+import org.apache.logging.log4j.Logger;
+import org.dspace.servicemanager.DSpaceKernelImpl;
+import org.dspace.servicemanager.DSpaceKernelInit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.fail;
+
+/**
+ * DSpace Unit Tests need to initialize the DSpace Kernel / Service Mgr
+ * in order to have access to configurations, etc. This Abstract class only
+ * initializes the Kernel (without full in-memory DB initialization).
+ * <P>
+ * Tests which just need the Kernel (or configs) can extend this class.
+ * <P>
+ * Tests which also need an in-memory DB should extend AbstractUnitTest or AbstractIntegrationTest
+ *
+ * @author Tim
+ * @see AbstractUnitTest
+ * @see AbstractIntegrationTest
+ */
+@Ignore
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractDSpaceTest {
+
+    /**
+     * Default constructor
+     */
+    protected AbstractDSpaceTest() { }
+
+    /**
+     * log4j category
+     */
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AbstractDSpaceTest.class);
+
+    /**
+     * Test properties. These configure our general test environment
+     */
+    protected static Properties testProps;
+
+    /**
+     * DSpace Kernel. Must be started to initialize ConfigurationService and
+     * any other services.
+     */
+    protected static DSpaceKernelImpl kernelImpl;
+
+    /**
+     * This method will be run before the first test as per @BeforeClass. It will
+     * initialize shared resources required for all tests of this class.
+     *
+     * This method loads our test properties to initialize our test environment,
+     * and then starts the DSpace Kernel (which allows access to services).
+     */
+    @BeforeClass
+    public static void initKernel() {
+        try {
+            //set a standard time zone for the tests
+            TimeZone.setDefault(TimeZone.getTimeZone("Europe/Dublin"));
+
+            //load the properties of the tests
+            testProps = new Properties();
+            URL properties = AbstractUnitTest.class.getClassLoader()
+                                                   .getResource("test-config.properties");
+            testProps.load(properties.openStream());
+
+            // Initialise the service manager kernel
+            kernelImpl = DSpaceKernelInit.getKernel(null);
+            if (!kernelImpl.isRunning()) {
+                // NOTE: the "dspace.dir" system property MUST be specified via Maven
+                // For example: by using <systemPropertyVariables> of maven-surefire-plugin or maven-failsafe-plugin
+                kernelImpl.start(getDspaceDir()); // init the kernel
+            }
+        } catch (IOException ex) {
+            log.error("Error initializing tests", ex);
+            fail("Error initializing tests: " + ex.getMessage());
+        }
+    }
+
+
+    /**
+     * This method will be run after all tests finish as per @AfterClass. It
+     * will clean resources initialized by the @BeforeClass methods.
+     */
+    @AfterClass
+    public static void destroyKernel() throws SQLException {
+        //we clear the properties
+        testProps.clear();
+        testProps = null;
+
+        //Also clear out the kernel & nullify (so JUnit will clean it up)
+        if (kernelImpl != null) {
+            kernelImpl.destroy();
+        }
+        kernelImpl = null;
+    }
+
+    public static String getDspaceDir() {
+        return System.getProperty("dspace.dir");
+
+    }
+}

--- a/src/test/java/org/dspace/AbstractUnitTest.java
+++ b/src/test/java/org/dspace/AbstractUnitTest.java
@@ -75,11 +75,6 @@ public class AbstractUnitTest extends AbstractDSpaceTest {
      */
     @BeforeClass
     public static void initDatabase() {
-        // Clear our old flyway object. Because this DB is in-memory, its
-        // data is lost when the last connection is closed. So, we need
-        // to (re)start Flyway from scratch for each Unit Test class.
-        DatabaseUtils.clearFlywayDBCache();
-
         try {
             // Update/Initialize the database to latest version (via Flyway)
             DatabaseUtils.updateDatabase();

--- a/src/test/java/org/dspace/AbstractUnitTest.java
+++ b/src/test/java/org/dspace/AbstractUnitTest.java
@@ -1,0 +1,193 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace;
+
+import java.sql.SQLException;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.logging.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.Context;
+import org.dspace.core.I18nUtil;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.EPersonService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.storage.rdbms.DatabaseUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+
+import static org.junit.Assert.fail;
+
+
+/**
+ * This is the base class for most Unit Tests. It contains some generic mocks and
+ * utilities that are needed by most of the unit tests developed for DSpace.
+ * <P>
+ * NOTE: This base class also performs in-memory (H2) database initialization.
+ * If your tests don't need that, you may wish to just use AbstractDSpaceTest.
+ *
+ * @author pvillega
+ * @see AbstractDSpaceTest
+ */
+@Ignore
+public class AbstractUnitTest extends AbstractDSpaceTest {
+    /**
+     * log4j category
+     */
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(AbstractUnitTest.class);
+
+    /**
+     * Context mock object to use in the tests.
+     */
+    protected Context context;
+
+    /**
+     * EPerson mock object to use in the tests.
+     */
+    protected EPerson eperson;
+
+    /**
+     * This service is used by the majority of DSO-based Unit tests, which
+     * is why it is initialized here.
+     */
+    protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
+
+    /**
+     * This method will be run before the first test as per @BeforeClass. It will
+     * initialize shared resources required for all tests of this class.
+     * <p>
+     * NOTE: Per JUnit, "The @BeforeClass methods of superclasses will be run before those the current class."
+     * http://junit.org/apidocs/org/junit/BeforeClass.html
+     * <p>
+     * This method builds on the initialization in AbstractDSpaceTest, and
+     * initializes the in-memory database for tests that need it.
+     */
+    @BeforeClass
+    public static void initDatabase() {
+        // Clear our old flyway object. Because this DB is in-memory, its
+        // data is lost when the last connection is closed. So, we need
+        // to (re)start Flyway from scratch for each Unit Test class.
+        DatabaseUtils.clearFlywayDBCache();
+
+        try {
+            // Update/Initialize the database to latest version (via Flyway)
+            DatabaseUtils.updateDatabase();
+        } catch (SQLException se) {
+            log.error("Error initializing database", se);
+            fail("Error initializing database: " + se.getMessage()
+                     + (se.getCause() == null ? "" : ": " + se.getCause().getMessage()));
+        }
+    }
+
+    /**
+     * This method will be run before every test as per @Before. It will
+     * initialize resources required for each individual unit test.
+     *
+     * Other methods can be annotated with @Before here or in subclasses
+     * but no execution order is guaranteed
+     */
+    @Before
+    public void init() {
+        try {
+            //Start a new context
+            context = new Context(Context.Mode.BATCH_EDIT);
+            context.turnOffAuthorisationSystem();
+
+            //Find our global test EPerson account. If it doesn't exist, create it.
+            EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
+            eperson = ePersonService.findByEmail(context, "test@email.com");
+            if (eperson == null) {
+                // This EPerson creation should only happen once (i.e. for first test run)
+                log.info("Creating initial EPerson (email=test@email.com) for Unit Tests");
+                eperson = ePersonService.create(context);
+                eperson.setFirstName(context, "first");
+                eperson.setLastName(context, "last");
+                eperson.setEmail("test@email.com");
+                eperson.setCanLogIn(true);
+                eperson.setLanguage(context, I18nUtil.getDefaultLocale().getLanguage());
+                // actually save the eperson to unit testing DB
+                ePersonService.update(context, eperson);
+            }
+            // Set our global test EPerson as the current user in DSpace
+            context.setCurrentUser(eperson);
+
+            // If our Anonymous/Administrator groups aren't initialized, initialize them as well
+            EPersonServiceFactory.getInstance().getGroupService().initDefaultGroupNames(context);
+
+            context.restoreAuthSystemState();
+
+            // Ensure all tests run with Solr indexing disabled
+            disableSolrIndexing();
+
+        } catch (AuthorizeException ex) {
+            log.error("Error creating initial eperson or default groups", ex);
+            fail("Error creating initial eperson or default groups in AbstractUnitTest init()");
+        } catch (SQLException ex) {
+            log.error(ex.getMessage(), ex);
+            fail("SQL Error on AbstractUnitTest init()");
+        }
+    }
+
+    /**
+     * This method will be run after every test as per @After. It will
+     * clean resources initialized by the @Before methods.
+     *
+     * Other methods can be annotated with @After here or in subclasses
+     * but no execution order is guaranteed
+     */
+    @After
+    public void destroy() {
+        // Cleanup our global context object
+        try {
+            cleanupContext(context);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Utility method to cleanup a created Context object (to save memory).
+     * This can also be used by individual tests to cleanup context objects they create.
+     */
+    protected void cleanupContext(Context c) throws SQLException {
+        // If context still valid, abort it
+        if (c != null && c.isValid()) {
+            c.abort();
+        }
+
+        // Cleanup Context object by setting it to null
+        if (c != null) {
+            c = null;
+        }
+    }
+
+    /**
+     * Utility method which ensures Solr indexing is DISABLED in all Tests. We turn this off because
+     * Solr is NOT used in the dspace-api test framework. Instead, Solr/Discovery indexing is
+     * exercised in the dspace-server Integration Tests (which use an embedded Solr).
+     */
+    protected static void disableSolrIndexing() {
+        // Get our currently configured list of event consumers
+        ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        String[] consumers = configurationService.getArrayProperty("event.dispatcher.default.consumers");
+
+        // Remove "discovery" from the configured consumers (if it exists).
+        // This turns off Discovery/Solr indexing after any object changes.
+        if (ArrayUtils.contains(consumers, "discovery")) {
+            consumers = ArrayUtils.removeElement(consumers, "discovery");
+            configurationService.setProperty("event.dispatcher.default.consumers", consumers);
+        }
+    }
+
+}

--- a/src/test/java/org/dspace/TestConfigurationService.java
+++ b/src/test/java/org/dspace/TestConfigurationService.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.dspace.services.ConfigurationService;
 
 /**
@@ -121,6 +121,13 @@ public class TestConfigurationService implements ConfigurationService {
     @Override
     public boolean hasProperty(String name) {
         return properties.containsKey(name);
+    }
+
+    @Override
+    public boolean addPropertyValue(String name, Object value) {
+        boolean isNew = properties.containsKey(name);
+        properties.put(name, value);
+        return isNew;
     }
 
     @Override

--- a/src/test/java/org/dspace/TestContentServiceFactory.java
+++ b/src/test/java/org/dspace/TestContentServiceFactory.java
@@ -12,22 +12,9 @@ import static org.mockito.Mockito.mock;
 import java.util.List;
 
 import org.dspace.content.DSpaceObject;
+import org.dspace.content.RelationshipMetadataService;
 import org.dspace.content.factory.ContentServiceFactory;
-import org.dspace.content.service.BitstreamFormatService;
-import org.dspace.content.service.BitstreamService;
-import org.dspace.content.service.BundleService;
-import org.dspace.content.service.CollectionService;
-import org.dspace.content.service.CommunityService;
-import org.dspace.content.service.DSpaceObjectLegacySupportService;
-import org.dspace.content.service.DSpaceObjectService;
-import org.dspace.content.service.InstallItemService;
-import org.dspace.content.service.ItemService;
-import org.dspace.content.service.MetadataFieldService;
-import org.dspace.content.service.MetadataSchemaService;
-import org.dspace.content.service.MetadataValueService;
-import org.dspace.content.service.SiteService;
-import org.dspace.content.service.SupervisedItemService;
-import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.content.service.*;
 
 /**
  * A {@link ContentServiceFactory} which returns mock services
@@ -116,6 +103,31 @@ public class TestContentServiceFactory extends ContentServiceFactory {
 
     @Override
     public SiteService getSiteService() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RelationshipTypeService getRelationshipTypeService() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RelationshipService getRelationshipService() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public EntityTypeService getEntityTypeService() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public EntityService getEntityService() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RelationshipMetadataService getRelationshipMetadataService() {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/test/java/org/dspace/TestDSpaceServicesFactory.java
+++ b/src/test/java/org/dspace/TestDSpaceServicesFactory.java
@@ -13,7 +13,6 @@ import org.dspace.services.ConfigurationService;
 import org.dspace.services.EmailService;
 import org.dspace.services.EventService;
 import org.dspace.services.RequestService;
-import org.dspace.services.SessionService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.utils.DSpace;
 
@@ -49,11 +48,6 @@ public class TestDSpaceServicesFactory extends DSpaceServicesFactory {
 
     @Override
     public RequestService getRequestService() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SessionService getSessionService() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/org/dspace/TestServiceManager.java
+++ b/src/test/java/org/dspace/TestServiceManager.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.dspace.kernel.ServiceManager;
+import org.springframework.context.ConfigurableApplicationContext;
 
 /**
  * Service manager which stores registered services in memory and returns them for use
@@ -22,6 +23,11 @@ import org.dspace.kernel.ServiceManager;
 public class TestServiceManager implements ServiceManager {
 
     private Map<String, Object> serviceNameMap = new HashMap<>();
+
+    @Override
+    public ConfigurableApplicationContext getApplicationContext() {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
     public <T> List<T> getServicesByType(Class<T> type) {

--- a/src/test/java/org/dspace/pack/bagit/BagItPackerTest.java
+++ b/src/test/java/org/dspace/pack/bagit/BagItPackerTest.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Field;
 import java.sql.SQLException;
 import java.util.UUID;
 
+import org.dspace.AbstractUnitTest;
 import org.dspace.TestAuthorizeServiceFactory;
 import org.dspace.TestConfigurationService;
 import org.dspace.TestContentServiceFactory;
@@ -46,7 +47,7 @@ import org.junit.Before;
  *
  * @author mikejritter
  */
-public abstract class BagItPackerTest {
+public abstract class BagItPackerTest extends AbstractUnitTest {
 
     public static final String EVENT_SERVICE_FACTORY = "eventServiceFactory";
     public static final String EPERSON_SERVICE_FACTORY = "ePersonServiceFactory";
@@ -57,6 +58,22 @@ public abstract class BagItPackerTest {
     private final EventServiceFactory eventServiceFactory = mock(EventServiceFactory.class);
 
     protected final String archFmt = "zip";
+
+    public BagItPackerTest() {
+        super();
+    }
+
+    @Before
+    @Override
+    public void init() {
+        super.init();
+    }
+
+    @After
+    @Override
+    public void destroy() {
+        super.destroy();
+    }
 
     @Before
     public void setup() throws SQLException {

--- a/src/test/java/org/dspace/pack/bagit/ItemPackerTest.java
+++ b/src/test/java/org/dspace/pack/bagit/ItemPackerTest.java
@@ -8,7 +8,7 @@
 package org.dspace.pack.bagit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.dspace.content.MetadataSchema.DC_SCHEMA;
+import static org.dspace.content.MetadataSchemaEnum.DC;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -168,11 +168,11 @@ public class ItemPackerTest extends BagItPackerTest {
         when(itemService.getMetadata(eq(item), eq(Item.ANY), eq(Item.ANY), eq(Item.ANY), eq(Item.ANY)))
             .thenReturn(Collections.singletonList(metadataValue));
 
-        when(bitstreamService.getMetadataFirstValue(eq(primaryBitstream), eq(DC_SCHEMA),
+        when(bitstreamService.getMetadataFirstValue(eq(primaryBitstream), eq(DC.getName()),
                                                     matches(bitstreamRegex), isNull(String.class),
                                                     eq(Item.ANY))).thenReturn(PRIMARY_NAME);
 
-        when(bitstreamService.getMetadataFirstValue(eq(licenseBitstream), eq(DC_SCHEMA),
+        when(bitstreamService.getMetadataFirstValue(eq(licenseBitstream), eq(DC.getName()),
                                                     matches(bitstreamRegex), isNull(String.class),
                                                     eq(Item.ANY))).thenReturn(LICENSE_NAME);
 
@@ -183,7 +183,7 @@ public class ItemPackerTest extends BagItPackerTest {
 
         when(bitstreamService.getFormat(any(Context.class), any(Bitstream.class))).thenReturn(bitstreamFormat);
 
-        when(bundleService.getMetadataFirstValue(eq(bundle), eq(DC_SCHEMA), eq(bitstreamTitle), isNull(String.class),
+        when(bundleService.getMetadataFirstValue(eq(bundle), eq(DC.getName()), eq(bitstreamTitle), isNull(String.class),
                                                  eq(Item.ANY))).thenReturn(BUNDLE_NAME);
 
         // and perform the packaging
@@ -193,12 +193,12 @@ public class ItemPackerTest extends BagItPackerTest {
         // verify all the interactions we outlined above
         verify(itemService, times(1)).isOwningCollection(eq(item), eq(owning));
         verify(itemService, times(1)).isOwningCollection(eq(item), eq(linked));
-        verify(bundleService, times(1)).getMetadataFirstValue(eq(bundle), eq(DC_SCHEMA), eq(bitstreamTitle),
+        verify(bundleService, times(1)).getMetadataFirstValue(eq(bundle), eq(DC.getName()), eq(bitstreamTitle),
                                                               isNull(String.class), eq(Item.ANY));
-        verify(bitstreamService, times(3)).getMetadataFirstValue(eq(primaryBitstream), eq(DC_SCHEMA),
+        verify(bitstreamService, times(3)).getMetadataFirstValue(eq(primaryBitstream), eq(DC.getName()),
                                                                  matches(bitstreamRegex),
                                                                  isNull(String.class), eq(Item.ANY));
-        verify(bitstreamService, times(3)).getMetadataFirstValue(eq(licenseBitstream), eq(DC_SCHEMA),
+        verify(bitstreamService, times(3)).getMetadataFirstValue(eq(licenseBitstream), eq(DC.getName()),
                                                                  matches(bitstreamRegex),
                                                                   isNull(String.class), eq(Item.ANY));
         verify(bitstreamService, times(2)).getFormat(any(Context.class), any(Bitstream.class));
@@ -230,11 +230,11 @@ public class ItemPackerTest extends BagItPackerTest {
         when(itemService.getMetadata(eq(item), eq(Item.ANY), eq(Item.ANY), eq(Item.ANY), eq(Item.ANY)))
             .thenReturn(Collections.singletonList(metadataValue));
 
-        when(bitstreamService.getMetadataFirstValue(eq(primaryBitstream), eq(DC_SCHEMA),
+        when(bitstreamService.getMetadataFirstValue(eq(primaryBitstream), eq(DC.getName()),
                                                     matches(bitstreamRegex), isNull(String.class),
                                                     eq(Item.ANY))).thenReturn(PRIMARY_NAME);
 
-        when(bitstreamService.getMetadataFirstValue(eq(licenseBitstream), eq(DC_SCHEMA),
+        when(bitstreamService.getMetadataFirstValue(eq(licenseBitstream), eq(DC.getName()),
                                                     matches(bitstreamRegex), isNull(String.class),
                                                     eq(Item.ANY))).thenReturn(LICENSE_NAME);
 
@@ -243,7 +243,7 @@ public class ItemPackerTest extends BagItPackerTest {
         when(bitstreamService.retrieve(any(Context.class), eq(licenseBitstream)))
             .thenReturn(new ByteArrayInputStream(LICENSE_NAME.getBytes()));
 
-        when(bundleService.getMetadataFirstValue(eq(bundle), eq(DC_SCHEMA), eq(bitstreamTitle), isNull(String.class),
+        when(bundleService.getMetadataFirstValue(eq(bundle), eq(DC.getName()), eq(bitstreamTitle), isNull(String.class),
                                                  eq(Item.ANY))).thenReturn(BUNDLE_NAME);
 
         // and perform the packaging
@@ -259,12 +259,12 @@ public class ItemPackerTest extends BagItPackerTest {
 
         // verify all the interactions we outlined above
         // 1 bundle.getName when looping the bundle, 2 from the ReferenceFilter
-        verify(bundleService, times(3)).getMetadataFirstValue(eq(bundle), eq(DC_SCHEMA), eq(bitstreamTitle),
+        verify(bundleService, times(3)).getMetadataFirstValue(eq(bundle), eq(DC.getName()), eq(bitstreamTitle),
                                                               isNull(String.class), eq(Item.ANY));
-        verify(bitstreamService, times(3)).getMetadataFirstValue(eq(primaryBitstream), eq(DC_SCHEMA),
+        verify(bitstreamService, times(3)).getMetadataFirstValue(eq(primaryBitstream), eq(DC.getName()),
                                                                  matches(bitstreamRegex),
                                                                  isNull(String.class), eq(Item.ANY));
-        verify(bitstreamService, times(3)).getMetadataFirstValue(eq(licenseBitstream), eq(DC_SCHEMA),
+        verify(bitstreamService, times(3)).getMetadataFirstValue(eq(licenseBitstream), eq(DC.getName()),
                                                                  matches(bitstreamRegex),
                                                                  isNull(String.class), eq(Item.ANY));
         verify(itemService, times(1)).getMetadata(eq(item), eq(Item.ANY), eq(Item.ANY), eq(Item.ANY), eq(Item.ANY));
@@ -333,12 +333,12 @@ public class ItemPackerTest extends BagItPackerTest {
         verify(bitstreamService, times(1)).create(any(Context.class), eq(originalBundle), any(InputStream.class));
 
         verify(bitstreamService, times(2)).setMetadataSingleValue(any(Context.class), eq(licenseBitstream),
-                                                                  eq(DC_SCHEMA), matches(metadataRegex),
+                                                                  eq(DC.getName()), matches(metadataRegex),
                                                                   isNull(String.class), isNull(String.class),
                                                                   anyString());
 
         verify(bitstreamService, times(3)).setMetadataSingleValue(any(Context.class), eq(originalBitstream),
-                                                                  eq(DC_SCHEMA), matches(metadataRegex),
+                                                                  eq(DC.getName()), matches(metadataRegex),
                                                                   isNull(String.class), isNull(String.class),
                                                                   anyString());
 

--- a/src/test/resources/test-config.properties
+++ b/src/test/resources/test-config.properties
@@ -1,0 +1,15 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+# Defines the test folder where the unit tests will be run
+# (Used by AbstractDSpaceTest)
+test.folder = ./target/testing/
+
+# Path of the test bitstream (to use in BitstreamTest and elsewhere)
+test.bitstream = ./target/testing/dspace/assetstore/ConstitutionofIreland.pdf
+test.exportcsv = ./target/testing/dspace/assetstore/test.csv
+test.importcsv = ./target/testing/dspace/assetstore/testImport.csv


### PR DESCRIPTION
This PR brings RTS up-to-date and functional in DSpace 7. This PR does _not_ include additional functionality for storing/restoring entity relationships, _nor_ does it implement tests of such functionality.

The following dependencies should be updated by DuraCloud, if possible, to bring them in-line with DSpace 7:
```
org.duracloud:common-queue --> com.amazonaws:aws-java-sdk-sqs:1.11.490
org.duracloud:common-json --> org.codehaus.jackson:jackson-xc:1.9.13
org.duracloud:common --> org.apache.httpcomponents:httpmime:4.5.3
org.duracloud.db:account-management-db-model --> org.springframework.security:spring-security-core:5.2.2.RELEASE
```

At this time, these dependencies (or their children) must be excluded from `dspace-replicate` for mvn to correctly build:
```
<dependency>
         <groupId>org.dspace</groupId>
         <artifactId>dspace-replicate</artifactId>
         <version>7.0-SNAPSHOT</version>
         <exclusions>
            <exclusion>
               <groupId>com.amazonaws</groupId>
               <artifactId>jmespath-java</artifactId>
            </exclusion>
            <exclusion>
               <groupId>com.amazonaws</groupId>
               <artifactId>aws-java-sdk-core</artifactId>
            </exclusion>
            <exclusion>
               <groupId>org.codehaus.jackson</groupId>
               <artifactId>jackson-mapper-asl</artifactId>
            </exclusion>
            <exclusion>
               <groupId>org.codehaus.jackson</groupId>
               <artifactId>jackson-core-asl</artifactId>
            </exclusion>
            <exclusion>
               <groupId>org.apache.httpcomponents</groupId>
               <artifactId>httpmime</artifactId>
            </exclusion>
            <exclusion>
               <groupId>org.springframework.security</groupId>
               <artifactId>spring-security-core</artifactId>
            </exclusion>
         </exclusions>
      </dependency>
```