### PR TITLE
Retry failed uploads for DuraCloudContentStore

### DIFF
--- a/config/modules/duracloud.cfg
+++ b/config/modules/duracloud.cfg
@@ -24,3 +24,13 @@ duracloud.context = durastore
 duracloud.username = rep-agent
 # DuraCloud password
 duracloud.password = passw0rd
+
+# Maximum number of retry attempts when uploading to DuraCloud
+duracloud.retry.max = 3
+
+# Time to wait between retry attempts in milliseconds
+duracloud.retry.wait = 1000
+
+# A multiplier to make waits between retries increase exponentially. The wait time will for each retry equals
+# (attempt ^ multiplier) * wait
+duracloud.retry.multiplier = 1

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -152,7 +152,7 @@ public class DuraCloudObjectStore implements ObjectStore {
     }
 
     private long uploadReplica(final String group, final File file, final String chkSum) throws IOException {
-        try {
+        try (final FileInputStream fileInputStream = new FileInputStream(file)) {
             //@TODO: We shouldn't need to pass a hardcoded MIME Type. Unfortunately, DuraCloud,
             // as of 1.3, doesn't properly determine a file's MIME Type. In future it should.
             final String mimeType;
@@ -174,7 +174,7 @@ public class DuraCloudObjectStore implements ObjectStore {
                 @Override
                 public String retry() throws Exception {
                     return dcStore.addContent(getSpaceID(group), getContentPrefix(group) + file.getName(),
-                                       new FileInputStream(file), file.length(),
+                                       fileInputStream, file.length(),
                                        mimeType, chkSum,
                                        new HashMap<String, String>());
                 }

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -7,6 +7,10 @@
  */
 package org.dspace.ctask.replicate.store;
 
+import static org.duracloud.common.retry.Retrier.DEFAULT_MAX_RETRIES;
+import static org.duracloud.common.retry.Retrier.DEFAULT_WAIT_BETWEEN_RETRIES;
+import static org.duracloud.common.retry.Retrier.DEFAULT_WAIT_MULTIPLIER;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -162,7 +166,11 @@ public class DuraCloudObjectStore implements ObjectStore {
                 mimeType = "application/octet-stream";
             }
 
-            new Retrier().execute(new Retriable() {
+            int maxRetries = configurationService.getIntProperty("duracloud.retry.max", DEFAULT_MAX_RETRIES);
+            int wait = configurationService.getIntProperty("duracloud.retry.wait", DEFAULT_WAIT_BETWEEN_RETRIES);
+            int multiplier = configurationService.getIntProperty("duracloud.retry.multiplier", DEFAULT_WAIT_MULTIPLIER);
+
+            new Retrier(maxRetries, wait, multiplier).execute(new Retriable() {
                 @Override
                 public String retry() throws Exception {
                     return dcStore.addContent(getSpaceID(group), getContentPrefix(group) + file.getName(),

--- a/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/DuraCloudObjectStore.java
@@ -153,15 +153,17 @@ public class DuraCloudObjectStore implements ObjectStore {
 
     private long uploadReplica(final String group, final File file, final String chkSum) throws IOException {
         try (final FileInputStream fileInputStream = new FileInputStream(file)) {
-            //@TODO: We shouldn't need to pass a hardcoded MIME Type. Unfortunately, DuraCloud,
-            // as of 1.3, doesn't properly determine a file's MIME Type. In future it should.
+            // get the mime type for DuraCloud
             final String mimeType;
-            if (file.getName().endsWith(".zip")) {
+            final String filename = file.getName();
+            if (filename.endsWith(".zip")) {
                 mimeType = "application/zip";
-            } else if (file.getName().endsWith(".tgz")) {
+            } else if (filename.endsWith(".tgz") || filename.endsWith(".gzip")) {
                 mimeType = "application/x-gzip";
-            } else if (file.getName().endsWith(".txt")) {
+            } else if (filename.endsWith(".txt")) {
                 mimeType = "text/plain";
+            } else if (filename.endsWith(".tar")) {
+                mimeType = "application/tar";
             } else {
                 mimeType = "application/octet-stream";
             }
@@ -173,7 +175,7 @@ public class DuraCloudObjectStore implements ObjectStore {
             new Retrier(maxRetries, wait, multiplier).execute(new Retriable() {
                 @Override
                 public String retry() throws Exception {
-                    return dcStore.addContent(getSpaceID(group), getContentPrefix(group) + file.getName(),
+                    return dcStore.addContent(getSpaceID(group), getContentPrefix(group) + filename,
                                        fileInputStream, file.length(),
                                        mimeType, chkSum,
                                        new HashMap<String, String>());

--- a/src/test/java/org/dspace/ctask/replicate/store/DuraCloudObjectStoreTest.java
+++ b/src/test/java/org/dspace/ctask/replicate/store/DuraCloudObjectStoreTest.java
@@ -1,0 +1,112 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.ctask.replicate.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+
+import org.duracloud.client.ContentStore;
+import org.duracloud.common.retry.Retrier;
+import org.duracloud.error.ContentStoreException;
+import org.duracloud.error.NotFoundException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+
+/**
+ * Tests for {@link DuraCloudObjectStore}. This creates a mock for the {@link ContentStore} so that we do not need to
+ * create outgoing requests to DuraCloud
+ */
+public class DuraCloudObjectStoreTest {
+
+    private final String group = "dc-object-store-test";
+    private final String mimeType = "application/zip";
+
+    private final ContentStore contentStore = mock(ContentStore.class);
+    private DuraCloudObjectStore objectStore;
+
+    @Before
+    public void setup() {
+        objectStore = new DuraCloudObjectStore();
+        objectStore.setContentStore(contentStore);
+    }
+
+    @Test
+    public void testUploadRetry() throws Exception {
+        final URL root = DuraCloudObjectStoreTest.class.getClassLoader().getResource("unpack");
+        // copy the file because the ObjectStore will delete it after transfer
+        final Path catalog = Paths.get(root.toURI()).resolve("catalog.zip");
+        final Path zipFile = Paths.get(root.toURI()).resolve("dc-upload.zip");
+        Files.copy(catalog, zipFile, StandardCopyOption.REPLACE_EXISTING);
+
+        assertThat(zipFile).exists();
+
+        // trigger uploadReplica
+        when(contentStore.getContentProperties(anyString(), anyString())).thenThrow(new NotFoundException("not found"));
+        // fail once then pass
+        when(contentStore.addContent(anyString(), anyString(), ArgumentMatchers.<InputStream>any(), anyLong(),
+                                     eq(mimeType), anyString(), ArgumentMatchers.<String, String>anyMap()))
+            .thenThrow(new ContentStoreException("first try fails"))
+            .thenReturn("second try succeeds");
+
+        objectStore.transferObject(group, zipFile.toFile());
+        assertThat(zipFile).doesNotExist();
+    }
+
+    @Test
+    public void testUploadFailure() throws Exception {
+        final URL root = DuraCloudObjectStoreTest.class.getClassLoader().getResource("unpack");
+        // copy the file because the ObjectStore will delete it after transfer
+        final Path catalog = Paths.get(root.toURI()).resolve("catalog.zip");
+        final Path zipFile = Paths.get(root.toURI()).resolve("dc-upload.zip");
+        Files.copy(catalog, zipFile, StandardCopyOption.REPLACE_EXISTING);
+
+        assertThat(zipFile).exists();
+
+        // trigger uploadReplica
+        when(contentStore.getContentProperties(anyString(), anyString())).thenReturn(new HashMap<String, String>());
+        // fail
+        when(contentStore.addContent(anyString(), anyString(), ArgumentMatchers.<InputStream>any(), anyLong(),
+                                     eq(mimeType), anyString(), ArgumentMatchers.<String, String>anyMap()))
+            .thenThrow(new ContentStoreException("exception"));
+
+        try {
+            objectStore.transferObject(group, zipFile.toFile());
+            fail("Expected transfer to fail");
+        } catch (IOException ignored) {
+        }
+
+        // verify that the retry process was attempted
+        final int numTries = 1 + Retrier.DEFAULT_MAX_RETRIES;
+        verify(contentStore, times(numTries)).addContent(anyString(), anyString(), ArgumentMatchers.<InputStream>any(),
+                                                         anyLong(), eq(mimeType), anyString(),
+                                                         ArgumentMatchers.<String, String>anyMap());
+
+        // we failed to upload, so the file should still exist
+        assertThat(zipFile).exists();
+        // and finish cleaning up
+        Files.delete(zipFile);
+    }
+
+}


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/DS-2000

* Use Retrier when uploading content to DuraCloud
* Add configuration properties for retrying uploads

