### PR TITLE
Moves DSpace version to 7.0, resolves several NullPointerExceptions encountered at runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <!-- DSpace Version Information (supported version of DSpace) -->
-        <dspace.version>7.0-beta5</dspace.version>
+        <dspace.version>7.0</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>7.0.0</duracloud.version>
         <!-- DuraSpace BagIt Support Library -->

--- a/src/main/java/org/dspace/ctask/replicate/FetchAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/FetchAIP.java
@@ -10,6 +10,7 @@ package org.dspace.ctask.replicate;
 
 import java.io.File;
 import java.io.IOException;
+import java.sql.SQLException;
 
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
@@ -19,7 +20,7 @@ import org.dspace.curate.Curator;
 /**
  * FetchAIP task will simply retrieve replica representations of the object
  * into the local staging area.
- * 
+ *
  * @author richardrodgers
  * @see TransmitAIP
  */
@@ -27,7 +28,7 @@ import org.dspace.curate.Curator;
 public class FetchAIP extends AbstractCurationTask
 {
     private String archFmt;
-    
+
     private String baseFolder;
 
     // Group where all AIPs are stored
@@ -40,7 +41,7 @@ public class FetchAIP extends AbstractCurationTask
         baseFolder = configurationService.getProperty("replicate.base.dir");
         storeGroupName = configurationService.getProperty("replicate.group.aip.name");
     }
-    
+
     /**
      * Perform the 'Fetch AIP' task
      * @param dso DSpace Object to perform on
@@ -52,10 +53,11 @@ public class FetchAIP extends AbstractCurationTask
     {
         if(dso!=null)
         {
-            //NOTE: we can get away with passing in a 'null' Context because
-            // the context isn't actually used to fetch the AIP
-            // (see below 'perform(ctx,id)' method)
-            return perform(null, dso.getHandle());
+            try {
+                return perform(Curator.curationContext(), dso.getHandle());
+            } catch (SQLException e) {
+                throw new IOException(e);
+            }
         }
         else
         {
@@ -65,8 +67,8 @@ public class FetchAIP extends AbstractCurationTask
             return Curator.CURATE_FAIL;
         }
     }
-    
-    
+
+
     /**
      * Perform the 'Fetch AIP' task
      * @param ctx DSpace Context
@@ -83,7 +85,7 @@ public class FetchAIP extends AbstractCurationTask
         boolean found = archive != null;
         String result = "AIP for object: " + id + " located : " + found + ".";
         if(found)
-            result += " AIP file downloaded to '" 
+            result += " AIP file downloaded to '"
                 + baseFolder + "/" + storeGroupName + "/" + objId + "'";
         report(result);
         setResult(result);

--- a/src/main/java/org/dspace/ctask/replicate/METSReplicateConsumer.java
+++ b/src/main/java/org/dspace/ctask/replicate/METSReplicateConsumer.java
@@ -430,7 +430,7 @@ public class METSReplicateConsumer implements Consumer {
         {
             // either marks end of current deletion or is member of
             // enclosing one: ignore if latter
-            if (delObjId.equals(id))
+            if (event.getDetail().equals(id) || (delObjId != null && delObjId.equals(id)))
             {
                 // determine owner and write out deletion catalog
                 if (Constants.COLLECTION == event.getSubjectType())

--- a/src/main/java/org/dspace/ctask/replicate/VerifyAIP.java
+++ b/src/main/java/org/dspace/ctask/replicate/VerifyAIP.java
@@ -9,6 +9,7 @@
 package org.dspace.ctask.replicate;
 
 import java.io.IOException;
+import java.sql.SQLException;
 
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
@@ -25,7 +26,7 @@ import org.dspace.curate.Suspendable;
  * once a single object fails the verification. However, when run from the Command-Line
  * this task will run to completion (i.e. even if an object fails it will continue
  * processing to completion).
- * 
+ *
  * @author richardrodgers
  * @see TransmitAIP
  */
@@ -33,7 +34,7 @@ import org.dspace.curate.Suspendable;
 public class VerifyAIP extends AbstractCurationTask
 {
     private String archFmt;
-    
+
     // Group where all AIPs are stored
     private String storeGroupName;
 
@@ -55,12 +56,12 @@ public class VerifyAIP extends AbstractCurationTask
     @Override
     public int perform(DSpaceObject dso) throws IOException
     {
-        if(dso!=null)
-        {
-            //NOTE: we can get away with passing in a 'null' Context because
-            // the context isn't actually used to verify whether an AIP exists
-            // (see below 'perform(ctx,id)' method)
-            return perform(null, dso.getHandle());
+        if(dso!=null) {
+            try {
+                return perform(Curator.curationContext(), dso.getHandle());
+            } catch (SQLException e) {
+                throw new IOException(e);
+            }
         }
         else
         {
@@ -70,7 +71,7 @@ public class VerifyAIP extends AbstractCurationTask
             return Curator.CURATE_FAIL;
         }
     }
-    
+
     /**
      * Performs the "Verify AIP" task.
      * <p>
@@ -78,13 +79,13 @@ public class VerifyAIP extends AbstractCurationTask
      * @param ctx DSpace Context
      * @param id ID of object to verify
      * @return integer which represents Curator return status
-     * @throws IOException if I/O error 
+     * @throws IOException if I/O error
      */
     @Override
     public int perform(Context ctx, String id) throws IOException
     {
         ReplicaManager repMan = ReplicaManager.instance();
-        
+
         String objId = repMan.storageId(ctx, id, archFmt);
         boolean found = repMan.objectExists(storeGroupName, objId);
         String result = "AIP for object: " + id + " found: " + found;

--- a/src/main/java/org/dspace/pack/PackerFactory.java
+++ b/src/main/java/org/dspace/pack/PackerFactory.java
@@ -24,7 +24,7 @@ import org.duraspace.bagit.profile.BagProfile;
 
 /**
  * PackerFactory mints packers for specified object types. Packer implementation
- * is based on a configurable property (packer.pkgtype). Currently, only 
+ * is based on a configurable property (packer.pkgtype). Currently, only
  * LC METS-based ("mets") and Bagit-based ("bagit") package formats are supported.
  *
  * @author richardrodgers
@@ -43,7 +43,7 @@ public class PackerFactory
     public static final String WITHDRAWN  = "withdrawn";
     public static final String BAG_PROFILE_KEY = "replicate-bagit.profile";
     public static final String DEFAULT_PROFILE = BagProfile.BuiltIn.BEYOND_THE_REPOSITORY.getIdentifier();
-    
+
     // type of package to use - must be either 'mets' or 'bagit'
     private static String packType = DSpaceServicesFactory.getInstance().getConfigurationService()
                                                           .getProperty("replicate.packer.pkgtype");
@@ -64,6 +64,7 @@ public class PackerFactory
                 metsPacker = new METSPacker(context, dso, archFmt);
             }
             else {
+                metsPacker.setContext(context);
                 metsPacker.setDSO(dso);
             }
             packer = metsPacker;


### PR DESCRIPTION
The NullPointerExceptions primarily revolved around Context objects not being provided or the Context not having the expected database connection. The change in PackerFactory is to allow the current context to be used rather than one cached from a previous request.