### PR TITLE
Update supported DSpace version range to 7.2 or above

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     </organization>
 
     <properties>
-        <!-- DSpace Version Information (supported version of DSpace is any 7.x release) -->
-        <dspace.version>7.1.1</dspace.version>
+        <!-- DSpace Version Information (supported version of DSpace is 7.2 or above) -->
+        <dspace.version>[7.2,7.20)</dspace.version>
         <!-- DuraCloud Version Information (supported version of DuraCloud) -->
         <duracloud.version>7.0.0</duracloud.version>
         <!-- DuraSpace BagIt Support Library -->


### PR DESCRIPTION
Minor update to POM for the 7.2 release of `dspace-replicate`.

This PR updates the supported versions of DSpace to 7.2 or above.  It appears that (at least currently), there's very little API changes in DSpace 7.x that would impact `dspace-replicate`.  So, this change will ensure that version 7.2 of `dspace-replicate` can also potentially be used with DSpace 7.3, 7.4, etc.