### PR TITLE
Fix #71: delete redundant copy of file in replica store

### DIFF
--- a/src/main/java/org/dspace/ctask/replicate/store/MountableObjectStore.java
+++ b/src/main/java/org/dspace/ctask/replicate/store/MountableObjectStore.java
@@ -44,7 +44,13 @@ public class MountableObjectStore extends LocalObjectStore
         {
             archFile.delete();
         }
+        
         Utils.copy(file, archFile);
-        return file.length();
+
+        long fileSize = file.length();
+        // Delete redundant copy from replica store
+        file.delete();
+        
+        return fileSize;
     }
 }


### PR DESCRIPTION
This PR fixes #71. It modifies the transferObject method of MountableObjectStore to delete the redundant file copy in replica store, to match the behaviour of LocalObjectStore.
